### PR TITLE
Render release notes as Markdown

### DIFF
--- a/src/NSync.Core/NSync.Core.csproj
+++ b/src/NSync.Core/NSync.Core.csproj
@@ -39,6 +39,9 @@
     <Reference Include="Ionic.Zip">
       <HintPath>..\packages\DotNetZip.1.9.1.8\lib\net20\Ionic.Zip.dll</HintPath>
     </Reference>
+    <Reference Include="MarkdownSharp">
+      <HintPath>..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Reactive.Testing, Version=1.1.11111.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Rx_Experimental-Testing.1.1.11111\lib\Net4-Full\Microsoft.Reactive.Testing.dll</HintPath>
     </Reference>

--- a/src/NSync.Core/ReleasePackage.cs
+++ b/src/NSync.Core/ReleasePackage.cs
@@ -52,9 +52,11 @@ namespace NSync.Core
                         });
                 });
 
-                removeDependenciesFromPackageSpec(tempPath.GetFiles("*.nuspec").First().FullName);
+                var specPath = tempPath.GetFiles("*.nuspec").First().FullName;
+                removeDependenciesFromPackageSpec(specPath);
                 removeSilverlightAssemblies(tempPath);
                 removeDeveloperDocumentation(tempPath);
+                renderReleaseNotesMarkdown(specPath);
 
                 zf = new ZipFile(outputFile);
                 zf.AddDirectory(tempPath.FullName);
@@ -141,22 +143,8 @@ namespace NSync.Core
                 x => this.Log().Info("Deleting {0}", x.Name)).ForEach(x => x.Delete(true));
         }
 
-        bool bytesAreIdentical(byte[] oldData, byte[] newData)
+        void renderReleaseNotesMarkdown(string specPath)
         {
-            if (oldData == null || newData == null) {
-                return oldData == newData;
-            }
-            if (oldData.LongLength != newData.LongLength) {
-                return false;
-            }
-
-            for(long i = 0; i < newData.LongLength; i++) {
-                if (oldData[i] != newData[i]) {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         void removeDependenciesFromPackageSpec(string specPath)
@@ -217,6 +205,22 @@ namespace NSync.Core
             });
         }
 
+        bool bytesAreIdentical(byte[] oldData, byte[] newData)
+        {
+            if (oldData == null || newData == null) {
+                return oldData == newData;
+            }
+            if (oldData.LongLength != newData.LongLength) {
+                return false;
+            }
 
+            for(long i = 0; i < newData.LongLength; i++) {
+                if (oldData[i] != newData[i]) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/src/NSync.Core/packages.config
+++ b/src/NSync.Core/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="DotNetZip" version="1.9.1.8" />
   <package id="Ix_Experimental-Main" version="1.1.10823" />
+  <package id="MarkdownSharp" version="1.13.0.0" />
   <package id="NLog" version="2.0.0.2000" />
   <package id="reactiveui-core" version="2.5.2.0" />
   <package id="Rx_Experimental-Main" version="1.1.11111" />

--- a/src/NSync.Tests/Core/ReleasePackageTests.cs
+++ b/src/NSync.Tests/Core/ReleasePackageTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using NSync.Core;
 using NSync.Tests.TestHelpers;
 using NuGet;
@@ -65,6 +66,29 @@ namespace NSync.Tests.Core
 
             IEnumerable<IPackage> results = fixture.findAllDependentPackages(null, sourceDir);
             results.Count().ShouldBeGreaterThan(0);
+        }
+
+        [Fact]
+        public void SpecFileMarkdownRenderingTest()
+        {
+            var dontcare = IntegrationTestHelper.GetPath("fixtures", "NSync.Core.1.1.0.0.nupkg");
+            var inputSpec = IntegrationTestHelper.GetPath("fixtures", "NSync.Core.1.1.0.0.nuspec");
+            var targetFile = Path.GetTempFileName();
+            File.Copy(inputSpec, targetFile, true);
+
+            try {
+                var fixture = ExposedObject.From(new ReleasePackage(dontcare));
+                fixture.renderReleaseNotesMarkdown(inputSpec);
+
+                var doc = XDocument.Load(targetFile);
+                XNamespace ns = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd";
+                var relNotesElement = doc.Descendants(ns + "releaseNotes").First();
+                var htmlText = relNotesElement.Value;
+
+                htmlText.Contains("## Release Notes").ShouldBeFalse();
+            } finally {
+                File.Delete(targetFile);
+            }
         }
     }
 

--- a/src/NSync.Tests/Core/ReleasePackageTests.cs
+++ b/src/NSync.Tests/Core/ReleasePackageTests.cs
@@ -84,7 +84,7 @@ namespace NSync.Tests.Core
                 // invulnerable to ExposedObject. Whyyyyyyyyy
                 var renderMinfo = fixture.GetType().GetMethod("renderReleaseNotesMarkdown", 
                     BindingFlags.NonPublic | BindingFlags.Instance);
-                renderMinfo.Invoke(fixture, new object[] {inputSpec});
+                renderMinfo.Invoke(fixture, new object[] {targetFile});
 
                 var doc = XDocument.Load(targetFile);
                 XNamespace ns = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd";

--- a/src/NSync.Tests/NSync.Tests.csproj
+++ b/src/NSync.Tests/NSync.Tests.csproj
@@ -40,6 +40,9 @@
     <Reference Include="Ionic.Zip">
       <HintPath>..\packages\DotNetZip.1.9.1.8\lib\net20\Ionic.Zip.dll</HintPath>
     </Reference>
+    <Reference Include="MarkdownSharp">
+      <HintPath>..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Reactive.Testing, Version=1.1.11111.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Rx_Experimental-Testing.1.1.11111\lib\Net4-Full\Microsoft.Reactive.Testing.dll</HintPath>
     </Reference>

--- a/src/NSync.Tests/TestHelpers/ExposedObject.cs
+++ b/src/NSync.Tests/TestHelpers/ExposedObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Dynamic;
 using System.Reflection;
@@ -86,11 +87,15 @@ namespace NSync.Tests.TestHelpers
             {
                 List<MethodInfo> methods = new List<MethodInfo>();
 
-                foreach (var method in m_genInstanceMethods[binder.Name][args.Length])
+                if (m_genInstanceMethods.ContainsKey(binder.Name) && 
+                    m_genInstanceMethods[binder.Name].ContainsKey(args.Length)) 
                 {
-                    if (method.GetGenericArguments().Length == typeArgs.Length)
+                    foreach (var method in m_genInstanceMethods[binder.Name][args.Length])
                     {
-                        methods.Add(method.MakeGenericMethod(typeArgs));
+                        if (method.GetGenericArguments().Length == typeArgs.Length)
+                        {
+                            methods.Add(method.MakeGenericMethod(typeArgs));
+                        }
                     }
                 }
 

--- a/src/NSync.Tests/fixtures/NSync.Core.1.1.0.0.nuspec
+++ b/src/NSync.Tests/fixtures/NSync.Core.1.1.0.0.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <version>1.1.0.0</version>
+    <authors>Administrator</authors>
+    <owners>Administrator</owners>
+    <dependencies>
+      <dependency id="DotNetZip" version="1.9.1.8" />
+      <dependency id="Ix_Experimental-Main" version="1.1.10823" />
+      <dependency id="NLog" version="2.0.0.2000" />
+      <dependency id="reactiveui-core" version="2.5.2.0" />
+    </dependencies>
+    <id>NSync.Core</id>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Description</description>
+    <releaseNotes>
+## Release Notes for 1.1
+
+1. Did some cool stuff
+1. Did another thing
+1. Did a third thing, pretty crazy!
+
+Make *sure* to refrobulate the confabulator or **terrible things will happen!**
+    </releaseNotes>
+  </metadata>
+  <files>
+    <file src="lib\net40\NSync.Core.dll" target="lib\net40\NSync.Core.dll" />
+  </files>
+</package>

--- a/src/NSync.Tests/fixtures/NSync.Core.1.1.0.0.nuspec
+++ b/src/NSync.Tests/fixtures/NSync.Core.1.1.0.0.nuspec
@@ -13,22 +13,15 @@
     <id>NSync.Core</id>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
-    <releaseNotes>&lt;![CDATA[
-&lt;p&gt;&lt;![CDATA[&lt;/p&gt;
+    <releaseNotes>
+## Release Notes for 1.1
 
-&lt;h2&gt;Release Notes for 1.1&lt;/h2&gt;
+1. Did some cool stuff
+1. Did another thing
+1. Did a third thing, pretty crazy!
 
-&lt;ol&gt;
-&lt;li&gt;Did some cool stuff&lt;/li&gt;
-&lt;li&gt;Did another thing&lt;/li&gt;
-&lt;li&gt;Did a third thing, pretty crazy!&lt;/li&gt;
-&lt;/ol&gt;
-
-&lt;p&gt;Make &lt;em&gt;sure&lt;/em&gt; to refrobulate the confabulator or &lt;strong&gt;terrible things will happen!&lt;/strong&gt;&lt;/p&gt;
-
-&lt;p&gt;]]&gt;&lt;/p&gt;
-
-]]&gt;</releaseNotes>
+Make *sure* to refrobulate the confabulator or **terrible things will happen!**
+    </releaseNotes>
   </metadata>
   <files>
     <file src="lib\net40\NSync.Core.dll" target="lib\net40\NSync.Core.dll" />

--- a/src/NSync.Tests/fixtures/NSync.Core.1.1.0.0.nuspec
+++ b/src/NSync.Tests/fixtures/NSync.Core.1.1.0.0.nuspec
@@ -13,15 +13,22 @@
     <id>NSync.Core</id>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
-    <releaseNotes>
-## Release Notes for 1.1
+    <releaseNotes>&lt;![CDATA[
+&lt;p&gt;&lt;![CDATA[&lt;/p&gt;
 
-1. Did some cool stuff
-1. Did another thing
-1. Did a third thing, pretty crazy!
+&lt;h2&gt;Release Notes for 1.1&lt;/h2&gt;
 
-Make *sure* to refrobulate the confabulator or **terrible things will happen!**
-    </releaseNotes>
+&lt;ol&gt;
+&lt;li&gt;Did some cool stuff&lt;/li&gt;
+&lt;li&gt;Did another thing&lt;/li&gt;
+&lt;li&gt;Did a third thing, pretty crazy!&lt;/li&gt;
+&lt;/ol&gt;
+
+&lt;p&gt;Make &lt;em&gt;sure&lt;/em&gt; to refrobulate the confabulator or &lt;strong&gt;terrible things will happen!&lt;/strong&gt;&lt;/p&gt;
+
+&lt;p&gt;]]&gt;&lt;/p&gt;
+
+]]&gt;</releaseNotes>
   </metadata>
   <files>
     <file src="lib\net40\NSync.Core.dll" target="lib\net40\NSync.Core.dll" />

--- a/src/NSync.Tests/packages.config
+++ b/src/NSync.Tests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="DotNetZip" version="1.9.1.8" />
   <package id="Ix_Experimental-Main" version="1.1.10823" />
+  <package id="MarkdownSharp" version="1.13.0.0" />
   <package id="Moq" version="4.0.10827" />
   <package id="Moq.Contrib" version="0.3" />
   <package id="NLog" version="2.0.0.2000" />


### PR DESCRIPTION
When we create Release Packages, we take the releaseNotes tag contents and rendering them in Markdown, according to [this part of the spec](https://github.com/xpaulbettsx/NSync/commit/41832491abd2b417c2b58cc84d86be3cf140a5d9#L0R63).
