### PR TITLE
UpdateManager changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+# NCrunch crap
+*ncrunch*

--- a/src/NSync.Client/NSync.Client.csproj
+++ b/src/NSync.Client/NSync.Client.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{3D17D46A-A411-4922-B932-9EBE2AAE0ED7}</ProjectGuid>
+    <ProjectGuid>{F23CEFD4-F1BA-4C37-A834-89A5E38055DD}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NSync.Client</RootNamespace>

--- a/src/NSync.Client/UpdateManager.cs
+++ b/src/NSync.Client/UpdateManager.cs
@@ -19,13 +19,14 @@ namespace NSync.Client
         Func<string, IObservable<string>> downloadUrl;
         string updateUrl;
 
+        // TODO: overload with default implementations for resolving package store and downloading resource
         public UpdateManager(string url, 
-            Func<string, Stream> openPathMock = null,
-            Func<string, IObservable<string>> downloadUrlMock = null)
+            Func<string, Stream> openPath = null,
+            Func<string, IObservable<string>> downloadUrl = null)
         {
             updateUrl = url;
-            openPath = openPathMock;
-            downloadUrl = downloadUrlMock;
+            this.openPath = openPath;
+            this.downloadUrl = downloadUrl;
         }
 
         public IObservable<UpdateInfo> CheckForUpdate()

--- a/src/NSync.Client/UpdateManager.cs
+++ b/src/NSync.Client/UpdateManager.cs
@@ -11,6 +11,7 @@ namespace NSync.Client
     public interface IUpdateManager
     {
         IObservable<UpdateInfo> CheckForUpdate();
+        void ApplyReleases(IEnumerable<ReleaseEntry> releasesToApply);
     }
 
     public class UpdateManager : IEnableLogger, IUpdateManager
@@ -44,6 +45,25 @@ namespace NSync.Client
 
             ret.Connect();
             return ret;
+        }
+
+        public void ApplyReleases(IEnumerable<ReleaseEntry> releasesToApply)
+        {
+            foreach (var p in releasesToApply)
+            {
+                var file = p.Filename;
+                // TODO: determine if we can use delta package
+                // TODO: download optimal package
+                // TODO: verify integrity of packages
+                // TODO: apply package changes to destination
+
+                // Q: is file in release relative path or can it support absolute path?
+                // Q: have left destination parameter out of this call
+                //      - shall NSync take care of the switching between current exe and new exe?
+                //      - pondering how to do this right now
+            }
+
+            // TODO: what shall we return? we may have issues with integrity of packages/missing packages etc
         }
 
         UpdateInfo determineUpdateInfo(IEnumerable<ReleaseEntry> localReleases, IEnumerable<ReleaseEntry> remoteReleases)

--- a/src/NSync.Core/NSync.Core.csproj
+++ b/src/NSync.Core/NSync.Core.csproj
@@ -42,16 +42,6 @@
     <Reference Include="MarkdownSharp">
       <HintPath>..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Reactive.Testing, Version=1.1.11111.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rx_Experimental-Testing.1.1.11111\lib\Net4-Full\Microsoft.Reactive.Testing.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Moq">
-      <HintPath>..\packages\Moq.Contrib.0.3\lib\Moq.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq.Contrib">
-      <HintPath>..\packages\Moq.Contrib.0.3\lib\Moq.Contrib.dll</HintPath>
-    </Reference>
     <Reference Include="NLog">
       <HintPath>..\packages\NLog.2.0.0.2000\lib\net40\NLog.dll</HintPath>
     </Reference>
@@ -60,9 +50,6 @@
     </Reference>
     <Reference Include="ReactiveUI">
       <HintPath>..\packages\reactiveui-core.2.5.2.0\lib\Net4\ReactiveUI.dll</HintPath>
-    </Reference>
-    <Reference Include="ReactiveUI.Testing">
-      <HintPath>..\packages\reactiveui-testing.2.5.2.0\lib\Net4\ReactiveUI.Testing.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -77,12 +64,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit">
-      <HintPath>..\packages\xunit.1.9.0.1566\lib\xunit.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.extensions">
-      <HintPath>..\packages\xunit.extensions.1.9.0.1566\lib\xunit.extensions.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BinaryPatchUtility.cs" />

--- a/src/NSync.Core/ReleaseEntry.cs
+++ b/src/NSync.Core/ReleaseEntry.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Security.Cryptography;
 
 namespace NSync.Core
 {

--- a/src/NSync.Core/ReleaseEntry.cs
+++ b/src/NSync.Core/ReleaseEntry.cs
@@ -54,7 +54,7 @@ namespace NSync.Core
             } 
         }
 
-        static readonly Regex entryRegex = new Regex(@"^([0-9a-fA-F]{40})\s+(\S+)\s+(\d+)$");
+        static readonly Regex entryRegex = new Regex(@"^([0-9a-fA-F]{40})\s+(\S+)\s+(\d+)[\r]*$");
         public static ReleaseEntry ParseReleaseEntry(string entry)
         {
             var m = entryRegex.Match(entry);


### PR DESCRIPTION
Using MarkPad as a guinea pig for these changes.
- Experimenting with API [here](https://github.com/shiftkey/DownmarkerWPF/compare/SpikeNSyncClient#diff-25)
- Demo providers for testing using flat files [here](https://github.com/shiftkey/DownmarkerWPF/compare/SpikeNSyncClient#diff-20) plugged into Autofac

**Changes**
- ApplyReleases stubbed out with what i think it should do. 
- Found a neat little bug with line endings and regex (AUTOCRLF RANDOM)
- nuked test assemblies in core into orbit

**TODO**
- i'm gonna need to create a real endpoint before long - to test real updates. EDIT: [oh snap too late](https://github.com/shiftkey/NSync.Server.Nancy)
- operations for downloading a file, unpacking the contents and applying the deltas
