### PR TITLE
Release entry creates invalid entries

### DIFF
--- a/src/NSync.Core/ReleaseEntry.cs
+++ b/src/NSync.Core/ReleaseEntry.cs
@@ -106,7 +106,7 @@ namespace NSync.Core
             Contract.Requires(!String.IsNullOrEmpty(filename));
 
             var hash = Utility.CalculateStreamSHA1(file); 
-            return new ReleaseEntry(hash, filename, file.Length, filenameIsDeltaFile(filename));
+            return new ReleaseEntry(hash, Path.GetFileName(filename), file.Length, filenameIsDeltaFile(filename));
         }
 
         public static ReleaseEntry GenerateFromFile(string filename)

--- a/src/NSync.Tests/Core/ReleaseEntryTests.cs
+++ b/src/NSync.Tests/Core/ReleaseEntryTests.cs
@@ -48,5 +48,13 @@ namespace NSync.Tests.Core
             Assert.Equal(expectedMajor, fixture.Version.Major);
             Assert.Equal(expectedMinor, fixture.Version.Minor);
         }
+
+        [Fact]
+        public void CanParseGeneratedReleaseEntryAsString()
+        {
+            var path = IntegrationTestHelper.GetPath("fixtures", "NSync.Core.1.1.0.0.nupkg");
+            var entryAsString = ReleaseEntry.GenerateFromFile(path).EntryAsString;
+            ReleaseEntry.ParseReleaseEntry(entryAsString);
+        }
     }
 }


### PR DESCRIPTION
If you call `ReleaseEntry.GenerateFromFile`, `ReleaseEntry.Filename` (and `ReleaseEntry.EntryAsString` consecutively) contains the complete path of the file. Passing that string to `ReleaseEntry.ParseReleaseEntry` fails, because the regular expression can't cope with it, especially if the path contains spaces.

This PR contains both a failing test and the fix. 

Although you use `System.IO.Abstraction` all over the place, I used `System.IO.Path.GetFilename` since it doesn't care if the file really exists. However, you might change it.
