### PR TITLE
exception when shortcut doesn't exist yet

### DIFF
--- a/src/NSync.Client/UpdateManager.cs
+++ b/src/NSync.Client/UpdateManager.cs
@@ -352,16 +352,21 @@ namespace NSync.Client
                     app.GetAppShortcutList()
                         .Where(x => !shortcutRequestsToIgnore.Contains(x))
                         .ForEach(x => {
-                            var sl = new ShellLink(x.GetLinkTarget(applicationName, true)) {
-                                Target = x.TargetPath,
-                                IconPath = x.IconLibrary,
-                                IconIndex = x.IconIndex,
-                                Arguments = x.Arguments,
-                                WorkingDirectory = x.WorkingDirectory,
-                                Description = x.Description
-                            };
+                            var linkTarget = x.GetLinkTarget(applicationName, true);
+                            var exists = File.Exists(linkTarget);
+                            var sl = exists ? new ShellLink(linkTarget) : new ShellLink();
+                            sl.Target = x.TargetPath;
+                            sl.IconPath = x.IconLibrary;
+                            sl.IconIndex = x.IconIndex;
+                            sl.Arguments = x.Arguments;
+                            sl.WorkingDirectory = x.WorkingDirectory;
+                            sl.Description = x.Description;
 
-                            sl.Save();
+                            if (exists) {
+                                sl.Save();
+                            } else {
+                                sl.Save(linkTarget);
+                            }
                         });
                 });
         }


### PR DESCRIPTION
The `ShellLink(string linkFile)` c'tor throws if the link file does not exist yet. I fixed that be first checking, if the file exists, and use the parameterless c'tor if not.

I didn't write a unit test, because all the `IAppSetup` related tests in `UpdateManagerTests`are not implemented yet.
