### PR TITLE
Provide a default IAppSetup in the case that the author didn't 

### DIFF
--- a/src/Shimmer.Client/IAppSetup.cs
+++ b/src/Shimmer.Client/IAppSetup.cs
@@ -153,11 +153,15 @@ namespace Shimmer.Client
             }
         }
 
+        protected virtual string Target {
+            get { return null; }
+        }
+
         public virtual IEnumerable<ShortcutCreationRequest> GetAppShortcutList()
         {
             // XXX: Make sure this trick actually works; we want the derived 
             // type's assembly
-            var target = this.GetType().Assembly.Location;
+            var target = Target ?? this.GetType().Assembly.Location;
 
             return new[] {
                 new ShortcutCreationRequest() {


### PR DESCRIPTION
In the case that the package author didn't follow directions, and none of their EXE files have IAppSetup implementations, create a default IAppSetup for every EXE file in the package.

This allows people who are very lazy to just run `Create-Release` and still get a functional installer out. Initial successes are important!
