### PR TITLE
Clean up how methods return progress

### DIFF
--- a/src/Shimmer.Client/BitsManager.cs
+++ b/src/Shimmer.Client/BitsManager.cs
@@ -15,8 +15,8 @@ namespace Shimmer.Client
 {
     public interface IUrlDownloader : IEnableLogger
     {
-        IObservable<string> DownloadUrl(string url, IObserver<int> progress = null);
-        IObservable<Unit> QueueBackgroundDownloads(IEnumerable<string> urls, IEnumerable<string> localPaths, IObserver<int> progress = null);
+        IObservable<string> DownloadUrl(string url, IObserver<int> progress);
+        IObservable<Unit> QueueBackgroundDownloads(IEnumerable<string> urls, IEnumerable<string> localPaths, IObserver<int> progress);
     }
 
     [Serializable]

--- a/src/Shimmer.Client/BitsManager.cs
+++ b/src/Shimmer.Client/BitsManager.cs
@@ -61,7 +61,7 @@ namespace Shimmer.Client
                             of.Write(x.Content, 0, x.Content.Length);
                         }
                     }, RxApp.TaskpoolScheduler))
-                 .Publish();
+                .Multicast(new ReplaySubject<Unit>());
 
             ret.Scan(0.0, (acc, _) => acc + toIncrement).Select(x => (int) x).Subscribe(progress);
 

--- a/src/Shimmer.Client/BitsManager.cs
+++ b/src/Shimmer.Client/BitsManager.cs
@@ -15,8 +15,8 @@ namespace Shimmer.Client
 {
     public interface IUrlDownloader : IEnableLogger
     {
-        IObservable<string> DownloadUrl(string url);
-        IObservable<int> QueueBackgroundDownloads(IEnumerable<string> urls, IEnumerable<string> localPaths);
+        IObservable<string> DownloadUrl(string url, IObserver<int> progress = null);
+        IObservable<Unit> QueueBackgroundDownloads(IEnumerable<string> urls, IEnumerable<string> localPaths, IObserver<int> progress = null);
     }
 
     [Serializable]
@@ -29,28 +29,44 @@ namespace Shimmer.Client
             this.fileSystem = fileSystem ?? AnonFileSystem.Default;
         }
 
-        public IObservable<string> DownloadUrl(string url)
+        public IObservable<string> DownloadUrl(string url, IObserver<int> progress = null)
         {
-            return Http.DownloadUrl(url).Select(x => Encoding.UTF8.GetString(x));
+            progress = progress ?? new Subject<int>();
+
+            var ret = Http.DownloadUrl(url)
+                .Select(x => Encoding.UTF8.GetString(x))
+                .PublishLast();
+
+            // NB: We don't actually have progress, fake it out
+            ret.Select(_ => 100).Subscribe(progress);
+
+            ret.Connect();
+            return ret;
         }
 
-        public IObservable<int> QueueBackgroundDownloads(IEnumerable<string> urls, IEnumerable<string> localPaths)
+        public IObservable<Unit> QueueBackgroundDownloads(IEnumerable<string> urls, IEnumerable<string> localPaths, IObserver<int> progress = null)
         {
             var fileCount = urls.Count();
             double toIncrement = 100.0 / fileCount;
+            progress = progress ?? new Subject<int>();
 
-            return urls.Zip(localPaths, (u, p) => new { Url = u, Path = p }).ToObservable()
-                .Select(x => Http.DownloadUrl(x.Url).Select(Content => new { x.Url, x.Path, Content })).Merge(4)
+            var ret = urls.Zip(localPaths, (u, p) => new { Url = u, Path = p }).ToObservable()
+                .Select(x => Http.DownloadUrl(x.Url).Select(Content => new { x.Url, x.Path, Content }))
+                .Merge(4)
                 .SelectMany(x => Observable.Start(() => {
-                    var fi = fileSystem.GetFileInfo(x.Path);
-                    if (fi.Exists) fi.Delete();
+                        var fi = fileSystem.GetFileInfo(x.Path);
+                        if (fi.Exists) fi.Delete();
 
-                    using (var of = fi.OpenWrite()) {
-                        of.Write(x.Content, 0, x.Content.Length);
-                    }
-                }, RxApp.TaskpoolScheduler))
-                .Scan(0.0, (acc, _) => acc + toIncrement)
-                .Select(x => (int)x);
+                        using (var of = fi.OpenWrite()) {
+                            of.Write(x.Content, 0, x.Content.Length);
+                        }
+                    }, RxApp.TaskpoolScheduler))
+                 .Publish();
+
+            ret.Scan(0.0, (acc, _) => acc + toIncrement).Select(x => (int) x).Subscribe(progress);
+
+            ret.Connect();
+            return ret.TakeLast(1).Select(_ => Unit.Default);
         }
 
         public void Dispose()
@@ -58,6 +74,8 @@ namespace Shimmer.Client
         }
     }
 
+    // NB: This code is hella wrong
+#if FALSE
     public class BitsException : Exception
     {
         public BitsError Error { get; protected set; }
@@ -123,4 +141,5 @@ namespace Shimmer.Client
             }
         }
     }
+#endif
 }

--- a/src/Shimmer.Client/IUpdateManager.cs
+++ b/src/Shimmer.Client/IUpdateManager.cs
@@ -30,18 +30,22 @@ namespace Shimmer.Client
         /// <param name="ignoreDeltaUpdates">Set this flag if applying a release
         /// fails to fall back to a full release, which takes longer to download
         /// but is less error-prone.</param>
+        /// <param name="progress">A Observer which can be used to report Progress - 
+        /// will return values from 0-100 and Complete, or Throw</param>
         /// <returns>An UpdateInfo object representing the updates to install.
         /// </returns>
-        IObservable<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates = false);
+        IObservable<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates = false, IObserver<int> progress = null);
 
         /// <summary>
         /// Download a list of releases into the local package directory.
         /// </summary>
         /// <param name="releasesToDownload">The list of releases to download, 
         /// almost always from UpdateInfo.ReleasesToApply.</param>
-        /// <returns>A progress Observable - will return values from 0-100 and
-        /// Complete, or Throw</returns>
-        IObservable<int> DownloadReleases(IEnumerable<ReleaseEntry> releasesToDownload);
+        /// <param name="progress">A Observer which can be used to report Progress - 
+        /// will return values from 0-100 and Complete, or Throw</param>
+        /// <returns>A completion Observable - either returns a single 
+        /// Unit.Default then Complete, or Throw</returns>
+        IObservable<Unit> DownloadReleases(IEnumerable<ReleaseEntry> releasesToDownload, IObserver<int> progress = null);
 
         /// <summary>
         /// Take an already downloaded set of releases and apply them, 
@@ -50,9 +54,11 @@ namespace Shimmer.Client
         /// </summary>
         /// <param name="updateInfo">The UpdateInfo instance acquired from 
         /// CheckForUpdate</param>
+        /// <param name="progress">A Observer which can be used to report Progress - 
+        /// will return values from 0-100 and Complete, or Throw</param>
         /// <returns>A progress Observable - will return values from 0-100 and
         /// Complete, or Throw</returns>
-        IObservable<int> ApplyReleases(UpdateInfo updateInfo);
+        IObservable<Unit> ApplyReleases(UpdateInfo updateInfo, IObserver<int> progress = null);
     }
 
     [ContractClassFor(typeof(IUpdateManager))]
@@ -63,23 +69,23 @@ namespace Shimmer.Client
             return default(IDisposable);
         }
 
-        public IObservable<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates = false)
+        public IObservable<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates = false, IObserver<int> progress = null)
         {
             return default(IObservable<UpdateInfo>);
         }
 
-        public IObservable<int> DownloadReleases(IEnumerable<ReleaseEntry> releasesToDownload)
+        public IObservable<Unit> DownloadReleases(IEnumerable<ReleaseEntry> releasesToDownload, IObserver<int> progress = null)
         {
             // XXX: Why doesn't this work?
             Contract.Requires(releasesToDownload != null);
             Contract.Requires(releasesToDownload.Any());
-            return default(IObservable<int>);
+            return default(IObservable<Unit>);
         }
 
-        public IObservable<int> ApplyReleases(UpdateInfo updateInfo)
+        public IObservable<Unit> ApplyReleases(UpdateInfo updateInfo, IObserver<int> progress = null)
         {
             Contract.Requires(updateInfo != null);
-            return default(IObservable<int>);
+            return default(IObservable<Unit>);
         }
     }
 

--- a/src/Shimmer.Client/IUpdateManager.cs
+++ b/src/Shimmer.Client/IUpdateManager.cs
@@ -34,7 +34,7 @@ namespace Shimmer.Client
         /// will return values from 0-100 and Complete, or Throw</param>
         /// <returns>An UpdateInfo object representing the updates to install.
         /// </returns>
-        IObservable<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates = false, IObserver<int> progress = null);
+        IObservable<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates, IObserver<int> progress);
 
         /// <summary>
         /// Download a list of releases into the local package directory.
@@ -45,7 +45,7 @@ namespace Shimmer.Client
         /// will return values from 0-100 and Complete, or Throw</param>
         /// <returns>A completion Observable - either returns a single 
         /// Unit.Default then Complete, or Throw</returns>
-        IObservable<Unit> DownloadReleases(IEnumerable<ReleaseEntry> releasesToDownload, IObserver<int> progress = null);
+        IObservable<Unit> DownloadReleases(IEnumerable<ReleaseEntry> releasesToDownload, IObserver<int> progress);
 
         /// <summary>
         /// Take an already downloaded set of releases and apply them, 
@@ -58,7 +58,7 @@ namespace Shimmer.Client
         /// will return values from 0-100 and Complete, or Throw</param>
         /// <returns>A progress Observable - will return values from 0-100 and
         /// Complete, or Throw</returns>
-        IObservable<Unit> ApplyReleases(UpdateInfo updateInfo, IObserver<int> progress = null);
+        IObservable<Unit> ApplyReleases(UpdateInfo updateInfo, IObserver<int> progress);
     }
 
     [ContractClassFor(typeof(IUpdateManager))]
@@ -104,9 +104,9 @@ namespace Shimmer.Client
                 return Observable.Throw<ReleaseEntry>(ex);
             }
 
-            var ret = This.CheckForUpdate()
-                .SelectMany(x => This.DownloadReleases(x.ReleasesToApply).TakeLast(1).Select(_ => x))
-                .SelectMany(x => This.ApplyReleases(x).TakeLast(1).Select(_ => x.ReleasesToApply.MaxBy(y => y.Version).LastOrDefault()))
+            var ret = This.CheckForUpdate(false, null)
+                .SelectMany(x => This.DownloadReleases(x.ReleasesToApply, null).TakeLast(1).Select(_ => x))
+                .SelectMany(x => This.ApplyReleases(x, null).TakeLast(1).Select(_ => x.ReleasesToApply.MaxBy(y => y.Version).LastOrDefault()))
                 .Finally(() => theLock.Dispose())
                 .Multicast(new AsyncSubject<ReleaseEntry>());
 

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -67,7 +67,7 @@ namespace Shimmer.Client
             get { return Path.Combine(PackageDirectory, "RELEASES"); }
         }
 
-        public IObservable<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates = false)
+        public IObservable<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates = false, IObserver<int> progress = null)
         {
             IEnumerable<ReleaseEntry> localReleases = Enumerable.Empty<ReleaseEntry>();
 

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -169,6 +169,7 @@ namespace Shimmer.Client
                     Observable.Start(() => installPackageToAppDir(updateInfo, release), RxApp.TaskpoolScheduler))
                 .Do(_ => progress.OnNext(95), progress.OnError)
                 .SelectMany(_ => UpdateLocalReleasesFile())
+                .Do(_ => progress.OnNext(100)).Finally(() => progress.OnCompleted())
                 .PublishLast();
 
             ret.Connect();

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -70,6 +70,7 @@ namespace Shimmer.Client
         public IObservable<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates = false, IObserver<int> progress = null)
         {
             IEnumerable<ReleaseEntry> localReleases = Enumerable.Empty<ReleaseEntry>();
+            progress = progress ?? new Subject<int>();
 
             var noLock = checkForLock<UpdateInfo>();
             if (noLock != null) return noLock;
@@ -92,7 +93,7 @@ namespace Shimmer.Client
             // Fetch the remote RELEASES file, whether it's a local dir or an 
             // HTTP URL
             if (isHttpUrl(updateUrlOrPath)) {
-                releaseFile = urlDownloader.DownloadUrl(String.Format("{0}/{1}", updateUrlOrPath, "RELEASES"));
+                releaseFile = urlDownloader.DownloadUrl(String.Format("{0}/{1}", updateUrlOrPath, "RELEASES"), progress);
             } else {
                 var fi = fileSystem.GetFileInfo(Path.Combine(updateUrlOrPath, "RELEASES"));
 
@@ -100,70 +101,77 @@ namespace Shimmer.Client
                     var text = sr.ReadToEnd();
                     releaseFile = Observable.Return(text);
                 }
+
+                progress.OnNext(100);
+                progress.OnCompleted();
             }
 
             var ret = releaseFile
                 .Select(ReleaseEntry.ParseReleaseFile)
                 .SelectMany(releases => determineUpdateInfo(localReleases, releases, ignoreDeltaUpdates))
-                .Multicast(new AsyncSubject<UpdateInfo>());
+                .PublishLast();
 
             ret.Connect();
             return ret;
         }
 
-        public IObservable<int> DownloadReleases(IEnumerable<ReleaseEntry> releasesToDownload)
+        public IObservable<Unit> DownloadReleases(IEnumerable<ReleaseEntry> releasesToDownload, IObserver<int> progress = null)
         {
-            var noLock = checkForLock<int>();
+            var noLock = checkForLock<Unit>();
             if (noLock != null) return noLock;
 
-            IObservable<int> downloadResult;
+            progress = progress ?? new Subject<int>();
+            IObservable<Unit> downloadResult = null;
 
             if (isHttpUrl(updateUrlOrPath)) {
                 var urls = releasesToDownload.Select(x => String.Format("{0}/{1}", updateUrlOrPath, x.Filename));
                 var paths = releasesToDownload.Select(x => Path.Combine(rootAppDirectory, "packages", x.Filename));
 
-                downloadResult = urlDownloader.QueueBackgroundDownloads(urls, paths);
+                downloadResult = urlDownloader.QueueBackgroundDownloads(urls, paths, progress);
             } else {
                 var toIncrement = 100.0 / releasesToDownload.Count();
 
                 // Do a parallel copy from the remote directory to the local
-                downloadResult = releasesToDownload.ToObservable()
+                var downloads = releasesToDownload.ToObservable()
                     .Select(x => fileSystem.CopyAsync(
                         Path.Combine(updateUrlOrPath, x.Filename),
                         Path.Combine(rootAppDirectory, "packages", x.Filename)))
                     .Merge(4)
+                    .Publish();
+
+                downloads
                     .Scan(0.0, (acc, _) => acc + toIncrement)
-                    .Select(x => (int)x);
+                    .Select(x => (int) x)
+                    .Subscribe(progress);
+
+                downloadResult = downloads.TakeLast(1);
+                downloads.Connect();
             }
 
-            return downloadResult
-                .Select(x => (int)(x * 0.95))
-                .Concat(checksumAllPackages(releasesToDownload).Select(_ => 100));
+            return downloadResult.SelectMany(_ => checksumAllPackages(releasesToDownload));
         }
 
-        public IObservable<int> ApplyReleases(UpdateInfo updateInfo)
+        public IObservable<Unit> ApplyReleases(UpdateInfo updateInfo, IObserver<int> progress = null)
         {
-            var noLock = checkForLock<int>();
+            var noLock = checkForLock<Unit>();
             if (noLock != null) return noLock;
-
-            // NB: This is so gross, but reporting accurate progress here is 
-            // just too damn hard.
-            var ret = new ReplaySubject<int>();
+            progress = progress ?? new Subject<int>();
 
             // NB: It's important that we update the local releases file *only* 
             // once the entire operation has completed, even though we technically
             // could do it after DownloadUpdates finishes. We do this so that if
             // we get interrupted / killed during this operation, we'll start over
-            cleanDeadVersions(updateInfo.CurrentlyInstalledVersion != null ? updateInfo.CurrentlyInstalledVersion.Version : null)
-                .Do(_ => ret.OnNext(10), ret.OnError)
+            var ret = cleanDeadVersions(updateInfo.CurrentlyInstalledVersion != null ? updateInfo.CurrentlyInstalledVersion.Version : null)
+                .Do(_ => progress.OnNext(10), progress.OnError)
                 .SelectMany(_ => createFullPackagesFromDeltas(updateInfo.ReleasesToApply, updateInfo.CurrentlyInstalledVersion))
-                .Do(_ => ret.OnNext(50), ret.OnError)
+                .Do(_ => progress.OnNext(50), progress.OnError)
                 .SelectMany(release =>
                     Observable.Start(() => installPackageToAppDir(updateInfo, release), RxApp.TaskpoolScheduler))
-                .Do(_ => ret.OnNext(95), ret.OnError)
+                .Do(_ => progress.OnNext(95), progress.OnError)
                 .SelectMany(_ => UpdateLocalReleasesFile())
-                .Subscribe(_ => ret.OnNext(100), ret.OnError, ret.OnCompleted);
+                .PublishLast();
 
+            ret.Connect();
             return ret;
         }
 

--- a/src/Shimmer.Tests/Client/BitsManagerTests.cs
+++ b/src/Shimmer.Tests/Client/BitsManagerTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Shimmer.Tests.Client
 {
+#if FALSE
     public class BitsManagerTests
     {
         [Fact(Skip = "Reenable this once we have proper BITS bindings")]
@@ -67,4 +68,5 @@ namespace Shimmer.Tests.Client
             }
         }
     }
+#endif
 }

--- a/src/Shimmer.Tests/Client/CheckForUpdateTests.cs
+++ b/src/Shimmer.Tests/Client/CheckForUpdateTests.cs
@@ -28,7 +28,7 @@ namespace Shimmer.Tests.Client
 
             var urlDownloader = new Mock<IUrlDownloader>();
             var dlPath = IntegrationTestHelper.GetPath("fixtures", "RELEASES-OnePointOne");
-            urlDownloader.Setup(x => x.DownloadUrl(It.IsAny<string>()))
+            urlDownloader.Setup(x => x.DownloadUrl(It.IsAny<string>(), It.IsAny<IObserver<int>>()))
                 .Returns(Observable.Return(File.ReadAllText(dlPath, Encoding.UTF8)));
 
             var fixture = new UpdateManager("http://lol", "theApp", FrameworkVersion.Net40, ".", fs.Object, urlDownloader.Object);
@@ -63,7 +63,7 @@ namespace Shimmer.Tests.Client
 
             var urlDownloader = new Mock<IUrlDownloader>();
             var dlPath = IntegrationTestHelper.GetPath("fixtures", "RELEASES-OnePointOne");
-            urlDownloader.Setup(x => x.DownloadUrl(It.IsAny<string>()))
+            urlDownloader.Setup(x => x.DownloadUrl(It.IsAny<string>(), It.IsAny<IObserver<int>>()))
                 .Returns(Observable.Return(File.ReadAllText(dlPath, Encoding.UTF8)));
 
             var fixture = new UpdateManager("http://lol", "theApp", FrameworkVersion.Net40, ".", fs.Object, urlDownloader.Object);
@@ -94,7 +94,7 @@ namespace Shimmer.Tests.Client
 
             var urlDownloader = new Mock<IUrlDownloader>();
             var dlPath = IntegrationTestHelper.GetPath("fixtures", "RELEASES-OnePointOne");
-            urlDownloader.Setup(x => x.DownloadUrl(It.IsAny<string>()))
+            urlDownloader.Setup(x => x.DownloadUrl(It.IsAny<string>(), It.IsAny<IObserver<int>>()))
                 .Returns(Observable.Return(File.ReadAllText(dlPath, Encoding.UTF8)));
 
             var fixture = new UpdateManager("http://lol", "theApp", FrameworkVersion.Net40, ".", fs.Object, urlDownloader.Object);
@@ -127,7 +127,7 @@ namespace Shimmer.Tests.Client
 
             var urlDownloader = new Mock<IUrlDownloader>();
             var dlPath = IntegrationTestHelper.GetPath("fixtures", "RELEASES-OnePointOne");
-            urlDownloader.Setup(x => x.DownloadUrl(It.IsAny<string>()))
+            urlDownloader.Setup(x => x.DownloadUrl(It.IsAny<string>(), It.IsAny<IObserver<int>>()))
                 .Returns(Observable.Return(File.ReadAllText(dlPath, Encoding.UTF8)));
 
             var fixture = new UpdateManager("http://lol", "theApp", FrameworkVersion.Net40, ".", fs.Object, urlDownloader.Object);
@@ -158,7 +158,7 @@ namespace Shimmer.Tests.Client
             fs.Setup(x => x.GetDirectoryInfo(localPackagesDir)).Returns(dirInfo.Object);
 
             var urlDownloader = new Mock<IUrlDownloader>();
-            urlDownloader.Setup(x => x.DownloadUrl(It.IsAny<string>()))
+            urlDownloader.Setup(x => x.DownloadUrl(It.IsAny<string>(), It.IsAny<IObserver<int>>()))
                 .Returns(Observable.Return("lol this isn't right"));
 
             var fixture = new UpdateManager("http://lol", "theApp", FrameworkVersion.Net40, ".", fs.Object, urlDownloader.Object);

--- a/src/Shimmer.Tests/Client/DownloadReleasesTests.cs
+++ b/src/Shimmer.Tests/Client/DownloadReleasesTests.cs
@@ -146,7 +146,7 @@ namespace Shimmer.Tests.Client
                 using (fixture.AcquireUpdateLock()) {
                     var progress = new ReplaySubject<int>();
 
-                    fixture.DownloadReleases(entriesToDownload).First();
+                    fixture.DownloadReleases(entriesToDownload, progress).First();
                     this.Log().Info("Progress: [{0}]", String.Join(",", progress));
 
                     progress.Buffer(2,1).All(x => x.Count != 2 || x[1] > x[0]).First().ShouldBeTrue();
@@ -187,7 +187,7 @@ namespace Shimmer.Tests.Client
                 using (fixture.AcquireUpdateLock()) {
                     var progress = new ReplaySubject<int>();
 
-                    fixture.DownloadReleases(entriesToDownload).First();
+                    fixture.DownloadReleases(entriesToDownload, progress).First();
                     this.Log().Info("Progress: [{0}]", String.Join(",", progress));
 
                     progress.Buffer(2,1).All(x => x.Count != 2 || x[1] > x[0]).First().ShouldBeTrue();

--- a/src/Shimmer.Tests/Client/DownloadReleasesTests.cs
+++ b/src/Shimmer.Tests/Client/DownloadReleasesTests.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Net;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Text;
 using Moq;
 using ReactiveUI;
@@ -143,9 +144,12 @@ namespace Shimmer.Tests.Client
 
                 var fixture = new UpdateManager("http://localhost:30405", "SampleUpdatingApp", FrameworkVersion.Net40, tempDir);
                 using (fixture.AcquireUpdateLock()) {
-                    var progress = fixture.DownloadReleases(entriesToDownload).ToList().First();
+                    var progress = new ReplaySubject<int>();
+
+                    fixture.DownloadReleases(entriesToDownload).First();
                     this.Log().Info("Progress: [{0}]", String.Join(",", progress));
-                    progress.Buffer(2,1).All(x => x.Count != 2 || x[1] > x[0]).ShouldBeTrue();
+
+                    progress.Buffer(2,1).All(x => x.Count != 2 || x[1] > x[0]).First().ShouldBeTrue();
                     progress.Last().ShouldEqual(100);
                 }
 
@@ -181,9 +185,12 @@ namespace Shimmer.Tests.Client
 
                 var fixture = new UpdateManager(updateDir.FullName, "SampleUpdatingApp", FrameworkVersion.Net40, tempDir);
                 using (fixture.AcquireUpdateLock()) {
-                    var progress = fixture.DownloadReleases(entriesToDownload).ToList().First();
+                    var progress = new ReplaySubject<int>();
+
+                    fixture.DownloadReleases(entriesToDownload).First();
                     this.Log().Info("Progress: [{0}]", String.Join(",", progress));
-                    progress.Buffer(2,1).All(x => x.Count != 2 || x[1] > x[0]).ShouldBeTrue();
+
+                    progress.Buffer(2,1).All(x => x.Count != 2 || x[1] > x[0]).First().ShouldBeTrue();
                     progress.Last().ShouldEqual(100);
                 }
 

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -143,6 +143,8 @@ namespace Shimmer.WiXUi.ViewModels
                 var fxVersion = determineFxVersionFromPackage(bundledPackageMetadata);
                 var eigenUpdater = new UpdateManager(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), BundledRelease.PackageName, fxVersion);
 
+#if FALSE
+                // XXX: This all changes soon, no sense in fixing it up
                 var eigenLock = eigenUpdater.AcquireUpdateLock();
 
                 var eigenUpdateProgress = eigenUpdater.CheckForUpdate()
@@ -178,6 +180,7 @@ namespace Shimmer.WiXUi.ViewModels
                     .Subscribe(
                         _ => wixEvents.Engine.Apply(wixEvents.MainWindowHwnd),
                         ex => UserError.Throw("Failed to install application", ex));
+#endif
             });
 
             wixEvents.ApplyCompleteObs.Subscribe(eventArgs => {


### PR DESCRIPTION
The notion of using an IObservable<int> as the return value for methods that return progress makes client code _really_ ugly. Let's separate these two.

Before, the pattern was:

``` cs
public IObservable<int> somethingThatReturnsProgress();
```

Now, it's:

``` cs
public IObservable<Unit> somethingThatReturnsProgress(IObserver<int> progress = null);
```

The idea being, that if you don't care about progress, don't pass in anything, but otherwise, pass in an `IObserver` that will have progress values played onto it. The easiest way to do this would be to use a `Subject`:

``` cs
var progress = new Subject<int>();
progress.Subscribe(x => setProgress(x));

somethingThatReturnsProgress(progress);
```
