### PR TITLE
Launch apps on install

### DIFF
--- a/src/Shimmer.Client/IAppSetup.cs
+++ b/src/Shimmer.Client/IAppSetup.cs
@@ -99,6 +99,12 @@ namespace Shimmer.Client
     public interface IAppSetup
     {
         /// <summary>
+        /// If this is 'true', this application will be launched when the 
+        /// application is initially installed.
+        /// </summary>
+        bool LaunchOnSetup { get; }
+
+        /// <summary>
         /// Get the list of shortcuts the EXE should install. Usually you would
         /// return a shortcut at least for the currently executing assembly (i.e.
         /// your own EXE).
@@ -153,32 +159,36 @@ namespace Shimmer.Client
             }
         }
 
+        public virtual bool LaunchOnSetup {
+            get { return true; }
+        }
+
+        string target;
         protected virtual string Target {
-            get { return null; }
+            // XXX: Make sure this trick actually works; we want the derived 
+            // type's assembly
+            get { return target ?? this.GetType().Assembly.Location; }
+            set { target = value; }
         }
 
         public virtual IEnumerable<ShortcutCreationRequest> GetAppShortcutList()
         {
-            // XXX: Make sure this trick actually works; we want the derived 
-            // type's assembly
-            var target = Target ?? this.GetType().Assembly.Location;
-
             return new[] {
                 new ShortcutCreationRequest() {
                     CreationLocation = ShortcutCreationLocation.Desktop,
                     Title = ShortcutName,
                     Description =  AppDescription,
-                    IconLibrary = target,
+                    IconLibrary = Target,
                     IconIndex = 0,
-                    TargetPath = target,
+                    TargetPath = Target,
                 },
                 new ShortcutCreationRequest() {
                     CreationLocation = ShortcutCreationLocation.StartMenu,
                     Title = ShortcutName,
                     Description =  AppDescription,
-                    IconLibrary = target,
+                    IconLibrary = Target,
                     IconIndex = 0,
-                    TargetPath = target,
+                    TargetPath = Target,
                 }
             };
         }

--- a/src/Shimmer.Client/IAppSetup.cs
+++ b/src/Shimmer.Client/IAppSetup.cs
@@ -105,6 +105,12 @@ namespace Shimmer.Client
         bool LaunchOnSetup { get; }
 
         /// <summary>
+        /// Returns the EXE file associated with this application. This is 
+        /// almost always the Assembly.Location of the entry assembly.
+        /// </summary>
+        string Target { get; }
+
+        /// <summary>
         /// Get the list of shortcuts the EXE should install. Usually you would
         /// return a shortcut at least for the currently executing assembly (i.e.
         /// your own EXE).
@@ -164,7 +170,7 @@ namespace Shimmer.Client
         }
 
         string target;
-        protected virtual string Target {
+        public virtual string Target {
             // XXX: Make sure this trick actually works; we want the derived 
             // type's assembly
             get { return target ?? this.GetType().Assembly.Location; }

--- a/src/Shimmer.Client/IUpdateManager.cs
+++ b/src/Shimmer.Client/IUpdateManager.cs
@@ -56,9 +56,9 @@ namespace Shimmer.Client
         /// CheckForUpdate</param>
         /// <param name="progress">A Observer which can be used to report Progress - 
         /// will return values from 0-100 and Complete, or Throw</param>
-        /// <returns>A progress Observable - will return values from 0-100 and
-        /// Complete, or Throw</returns>
-        IObservable<Unit> ApplyReleases(UpdateInfo updateInfo, IObserver<int> progress);
+        /// <returns>A list of EXEs that should be started if this is a new 
+        /// installation.</returns>
+        IObservable<List<string>> ApplyReleases(UpdateInfo updateInfo, IObserver<int> progress);
     }
 
     [ContractClassFor(typeof(IUpdateManager))]
@@ -82,10 +82,10 @@ namespace Shimmer.Client
             return default(IObservable<Unit>);
         }
 
-        public IObservable<Unit> ApplyReleases(UpdateInfo updateInfo, IObserver<int> progress = null)
+        public IObservable<List<string>> ApplyReleases(UpdateInfo updateInfo, IObserver<int> progress = null)
         {
             Contract.Requires(updateInfo != null);
-            return default(IObservable<Unit>);
+            return default(IObservable<List<string>>);
         }
     }
 

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -154,6 +154,7 @@ namespace Shimmer.WiXUi.ViewModels
 
                 if (wixEvents.DisplayMode != Display.Full || wixEvents.Action != LaunchAction.Install) {
                     wixEvents.ShouldQuit();
+                    return;
                 }
 
                 foreach (var path in executablesToStart) { Process.Start(path); }

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
@@ -210,11 +211,11 @@ namespace Shimmer.WiXUi.ViewModels
                     realUpdater.CheckForUpdate(progress: realCheckProgress)
                         .SelectMany(x => realUpdater.DownloadReleases(x.ReleasesToApply, realCopyFileProgress).Select(_ => x))
                         .SelectMany(x => realUpdater.ApplyReleases(x, realApplyProgress))
-                        .LoggedCatch<Unit, WixUiBootstrapper, Exception>(this, ex => {
+                        .LoggedCatch<List<string>, WixUiBootstrapper, Exception>(this, ex => {
                             // NB: If we don't do this, we won't Collapse the Wave 
                             // Function(tm) below on 'progress' and it will never complete
                             realCheckProgress.OnError(ex);
-                            return Observable.Return(Unit.Default);
+                            return Observable.Return(Enumerable.Empty<string>().ToList());
                         }, "Failed to update to latest remote version")
                         .First();
                 }

--- a/src/ShimmerIAppUpdateTestTarget/TestAppSetup.cs
+++ b/src/ShimmerIAppUpdateTestTarget/TestAppSetup.cs
@@ -18,6 +18,14 @@ namespace ShimmerIAppUpdateTestTarget
     // work.
     public class TestAppSetup : IAppSetup
     {
+        public string Target {
+            get { return Assembly.GetExecutingAssembly().Location; }
+        }
+
+        public bool LaunchOnSetup {
+            get { return true; }
+        }
+
         public IEnumerable<ShortcutCreationRequest> GetAppShortcutList()
         {
             if (shouldThrow()) {


### PR DESCRIPTION
This PR launches any apps marked as "should start on install" (and a new `IAppSetup` property to indicate that the app should be run, since one package can install > 1 EXE file). 
