### PR TITLE
Installer refactor

### DIFF
--- a/src/Shimmer.Client/InstallManager.cs
+++ b/src/Shimmer.Client/InstallManager.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+using NuGet;
+using ReactiveUIMicro;
+using Shimmer.Core;
+
+namespace Shimmer.Client
+{
+    public interface IInstallManager
+    {
+        IObservable<List<string>> ExecuteInstall(string currentAssemblyDir, IPackage bundledPackageMetadata, IObserver<int> progress = null);
+        IObservable<Unit> ExecuteUninstall();
+    }
+
+    public class InstallManager : IInstallManager
+    {
+        public ReleaseEntry BundledRelease { get; protected set; }
+        public string TargetRootDirectory { get; protected set; }
+
+        public InstallManager(ReleaseEntry bundledRelease, string targetRootDirectory = null)
+        {
+            BundledRelease = bundledRelease;
+            TargetRootDirectory = targetRootDirectory;
+        }
+
+        public IObservable<List<string>> ExecuteInstall(string currentAssemblyDir, IPackage bundledPackageMetadata, IObserver<int> progress = null)
+        {
+            progress = progress ?? new Subject<int>();
+
+            // NB: This bit of code is a bit clever. The binaries that WiX 
+            // has installed *itself* meets the qualifications for being a
+            // Shimmer update directory (a RELEASES file and the corresponding 
+            // NuGet packages). 
+            //
+            // So, in order to reuse some code and not write the same things 
+            // twice we're going to "Eigenupdate" from our own directory; 
+            // UpdateManager will operate in bootstrap mode and create a 
+            // local directory for us. 
+            //
+            // Then, we create a *new* UpdateManager whose target is the normal 
+            // update URL - we can then apply delta updates against the bundled 
+            // NuGet package to get up to vCurrent. The reason we go through
+            // this rigamarole is so that developers don't have to rebuild the 
+            // installer as often (never, technically).
+
+            return Observable.Start(() => {
+                var fxVersion = determineFxVersionFromPackage(bundledPackageMetadata);
+                var eigenUpdater = new UpdateManager(currentAssemblyDir, bundledPackageMetadata.Id, fxVersion, TargetRootDirectory);
+
+                var eigenCheckProgress = new Subject<int>();
+                var eigenCopyFileProgress = new Subject<int>();
+                var eigenApplyProgress = new Subject<int>();
+
+                var realCheckProgress = new Subject<int>();
+                var realCopyFileProgress = new Subject<int>();
+                var realApplyProgress = new Subject<int>();
+
+                // The real update takes longer than the eigenupdate because we're
+                // downloading from the Internet instead of doing everything 
+                // locally, so give it more weight
+                Observable.Concat(
+                        Observable.Concat(eigenCheckProgress, eigenCopyFileProgress, eigenCopyFileProgress).Select(x => (x / 3.0) * 0.33),
+                        Observable.Concat(realCheckProgress, realCopyFileProgress, realApplyProgress).Select(x => (x / 3.0) * 0.67))
+                    .Select(x => (int)x)
+                    .Subscribe(progress);
+
+                List<string> ret = null;
+                using (eigenUpdater.AcquireUpdateLock()) {
+                    ret = eigenUpdater.CheckForUpdate(progress: eigenCheckProgress)
+                        .SelectMany(x => eigenUpdater.DownloadReleases(x.ReleasesToApply, eigenCopyFileProgress).Select(_ => x))
+                        .SelectMany(x => eigenUpdater.ApplyReleases(x, eigenApplyProgress))
+                        .First();
+                }
+
+                var updateUrl = bundledPackageMetadata.ProjectUrl != null ? bundledPackageMetadata.ProjectUrl.ToString() : null;
+                var realUpdater = new UpdateManager(updateUrl, bundledPackageMetadata.Id, fxVersion, TargetRootDirectory);
+
+                using (realUpdater.AcquireUpdateLock()) {
+                    realUpdater.CheckForUpdate(progress: realCheckProgress)
+                        .SelectMany(x => realUpdater.DownloadReleases(x.ReleasesToApply, realCopyFileProgress).Select(_ => x))
+                        .SelectMany(x => realUpdater.ApplyReleases(x, realApplyProgress))
+                        .LoggedCatch<List<string>, InstallManager, Exception>(this, ex => {
+                            // NB: If we don't do this, we won't Collapse the Wave 
+                            // Function(tm) below on 'progress' and it will never complete
+                            realCheckProgress.OnError(ex);
+                            return Observable.Return(Enumerable.Empty<string>().ToList());
+                        }, "Failed to update to latest remote version")
+                        .First();
+                }
+
+                return ret;
+            }).ObserveOn(RxApp.DeferredScheduler);
+        }
+
+        public IObservable<Unit> ExecuteUninstall()
+        {
+            var updateManager = new UpdateManager("http://lol", BundledRelease.PackageName, FrameworkVersion.Net40, TargetRootDirectory);
+
+            var updateLock = updateManager.AcquireUpdateLock();
+
+            return updateManager.FullUninstall()
+                .ObserveOn(RxApp.DeferredScheduler)
+                .Log(this, "Full uninstall") 
+                .Finally(updateLock.Dispose);
+        }
+
+        static FrameworkVersion determineFxVersionFromPackage(IPackage package)
+        {
+            return package.GetFiles().Any(x => x.Path.Contains("lib") && x.Path.Contains("45"))
+                ? FrameworkVersion.Net45
+                : FrameworkVersion.Net40;
+        }
+    }
+}

--- a/src/Shimmer.Client/Shimmer.Client.csproj
+++ b/src/Shimmer.Client/Shimmer.Client.csproj
@@ -120,6 +120,7 @@
   <ItemGroup>
     <Compile Include="BitsManager.cs" />
     <Compile Include="IAppSetup.cs" />
+    <Compile Include="InstallManager.cs" />
     <Compile Include="IUpdateManager.cs" />
     <Compile Include="PostInstallInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Shimmer.Core/ReactiveUIMicro/ReactiveUI/Logging.cs
+++ b/src/Shimmer.Core/ReactiveUIMicro/ReactiveUI/Logging.cs
@@ -169,20 +169,20 @@ namespace ReactiveUIMicro
             TObj klass, 
             string message = null,
             Func<T, string> stringifier = null)
-            where TObj : IEnableLogger
         {
             message = message ?? "";
 
+            var log = LogManager.GetLogger<TObj>();
             if (stringifier != null) {
                 return This.Do(
-                    x => klass.Log().Info("{0} OnNext: {1}", message, stringifier(x)),
-                    ex => klass.Log().WarnException(message + " " + "OnError", ex),
-                    () => klass.Log().Info("{0} OnCompleted", message));
+                    x => log.Info("{0} OnNext: {1}", message, stringifier(x)),
+                    ex => log.WarnException(message + " " + "OnError", ex),
+                    () => log.Info("{0} OnCompleted", message));
             } else {
                 return This.Do(
-                    x => klass.Log().Info("{0} OnNext: {1}", message, x),
-                    ex => klass.Log().WarnException(message + " " + "OnError", ex),
-                    () => klass.Log().Info("{0} OnCompleted", message));
+                    x => log.Info("{0} OnNext: {1}", message, x),
+                    ex => log.WarnException(message + " " + "OnError", ex),
+                    () => log.Info("{0} OnCompleted", message));
             }
         }
 

--- a/src/Shimmer.Tests/Client/InstallManagerTests.cs
+++ b/src/Shimmer.Tests/Client/InstallManagerTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reflection;
+using System.Text;
+using Microsoft.Tools.WindowsInstallerXml.Bootstrapper;
+using Moq;
+using NuGet;
+using Shimmer.Client;
+using Shimmer.Client.WiXUi;
+using Shimmer.Core;
+using Shimmer.Tests.TestHelpers;
+using Shimmer.WiXUi.ViewModels;
+using Xunit;
+using ErrorEventArgs = Microsoft.Tools.WindowsInstallerXml.Bootstrapper.ErrorEventArgs;
+
+namespace Shimmer.Tests.Client
+{
+    public class InstallManagerTests
+    {
+        [Fact]
+        public void EigenUpdateWithoutUpdateURL()
+        {
+            string dir;
+            string outDir;
+
+            using (Utility.WithTempDirectory(out outDir))
+            using (IntegrationTestHelper.WithFakeInstallDirectory(out dir)) {
+                var di = new DirectoryInfo(dir);
+                var progress = new Subject<int>();
+
+                var bundledRelease = ReleaseEntry.GenerateFromFile(di.GetFiles("*.nupkg").First().FullName);
+                var fixture = new InstallManager(bundledRelease, outDir);
+                var pkg = new ZipPackage(Path.Combine(dir, "SampleUpdatingApp.1.1.0.0.nupkg"));
+
+                var progressValues = new List<int>();
+                progress.Subscribe(progressValues.Add);
+
+                fixture.ExecuteInstall(dir, pkg, progress);
+
+                var filesToLookFor = new[] {
+                    "SampleUpdatingApp\\app-1.1.0.0\\SampleUpdatingApp.exe",
+                    "SampleUpdatingApp\\packages\\RELEASES",
+                    "SampleUpdatingApp\\packages\\SampleUpdatingApp.1.1.0.0.nupkg",
+                };
+
+                filesToLookFor.All(x => File.Exists(Path.Combine(outDir, x))).ShouldBeTrue();
+
+                // Progress should be monotonically increasing
+                progressValues.Count.ShouldBeGreaterThan(2);
+                progressValues.Zip(progressValues.Skip(1), (prev, cur) => cur - prev).All(x => x > 0).ShouldBeTrue();
+            }
+        }
+
+        [Fact]
+        public void EigenUpdateWithUpdateURL()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void UpdateReportsProgress()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void InstallHandlesAccessDenied()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void UninstallRunsHooks()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void UninstallRemovesEverything()
+        {
+            string dir;
+            string appDir;
+
+            using (IntegrationTestHelper.WithFakeInstallDirectory(out dir))
+            using (IntegrationTestHelper.WithFakeAlreadyInstalledApp(out appDir)) {
+                var di = new DirectoryInfo(dir);
+                var progress = new Subject<int>();
+
+                var bundledRelease = ReleaseEntry.GenerateFromFile(di.GetFiles("*.nupkg").First().FullName);
+                var fixture = new InstallManager(bundledRelease, appDir);
+
+                var progressValues = new List<int>();
+                progress.Subscribe(progressValues.Add);
+
+                fixture.ExecuteUninstall().First();
+
+                di = new DirectoryInfo(appDir);
+                di.GetDirectories().Any().ShouldBeFalse();
+                di.GetFiles().Any().ShouldBeFalse();
+            }
+        }
+    }
+}

--- a/src/Shimmer.Tests/Shimmer.Tests.csproj
+++ b/src/Shimmer.Tests/Shimmer.Tests.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Client\BitsManagerTests.cs" />
     <Compile Include="Client\CheckForUpdateTests.cs" />
     <Compile Include="Client\DownloadReleasesTests.cs" />
+    <Compile Include="Client\InstallManagerTests.cs" />
     <Compile Include="Client\UpdateManagerTests.cs" />
     <Compile Include="Core\AppDomainHelperTests.cs" />
     <Compile Include="Core\DeltaPackageTests.cs" />

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -115,13 +115,13 @@ namespace Shimmer.WiXUi.ViewModels
             var executablesToStart = Enumerable.Empty<string>();
 
             wixEvents.PlanCompleteObs.Subscribe(eventArgs => {
+                var installManager = new InstallManager(BundledRelease);
                 var error = convertHResultToError(eventArgs.Status);
                 if (error != null) {
                     UserError.Throw(error);
                     return;
                 }
 
-                var installManager = new InstallManager(BundledRelease);
                 if (wixEvents.Action == LaunchAction.Uninstall) {
                     installManager.ExecuteUninstall().Subscribe(
                         _ => wixEvents.Engine.Apply(wixEvents.MainWindowHwnd),
@@ -138,7 +138,7 @@ namespace Shimmer.WiXUi.ViewModels
                     Router.Navigate.Execute(installingVm);
                 }
 
-                executeInstall(currentAssemblyDir, bundledPackageMetadata.Value, progress).Subscribe(
+                installManager.ExecuteInstall(currentAssemblyDir, bundledPackageMetadata.Value, progress).Subscribe(
                     toStart => {
                         executablesToStart = toStart ?? executablesToStart;
                         wixEvents.Engine.Apply(wixEvents.MainWindowHwnd);

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -121,8 +121,9 @@ namespace Shimmer.WiXUi.ViewModels
                     return;
                 }
 
+                var installManager = new InstallManager(BundledRelease);
                 if (wixEvents.Action == LaunchAction.Uninstall) {
-                    executeUninstall().Subscribe(
+                    installManager.ExecuteUninstall().Subscribe(
                         _ => wixEvents.Engine.Apply(wixEvents.MainWindowHwnd),
                         ex => UserError.Throw(new UserError("Failed to uninstall", ex.Message, innerException: ex)));
                     return;
@@ -163,86 +164,6 @@ namespace Shimmer.WiXUi.ViewModels
             wixEvents.ErrorObs.Subscribe(eventArgs => UserError.Throw("An installation error has occurred: " + eventArgs.ErrorMessage));
         }
 
-        IObservable<List<string>> executeInstall(string currentAssemblyDir, IPackage bundledPackageMetadata, IObserver<int> progress = null, string targetRootDirectory = null)
-        {
-            progress = progress ?? new Subject<int>();
-
-            // NB: This bit of code is a bit clever. The binaries that WiX 
-            // has installed *itself* meets the qualifications for being a
-            // Shimmer update directory (a RELEASES file and the corresponding 
-            // NuGet packages). 
-            //
-            // So, in order to reuse some code and not write the same things 
-            // twice we're going to "Eigenupdate" from our own directory; 
-            // UpdateManager will operate in bootstrap mode and create a 
-            // local directory for us. 
-            //
-            // Then, we create a *new* UpdateManager whose target is the normal 
-            // update URL - we can then apply delta updates against the bundled 
-            // NuGet package to get up to vCurrent. The reason we go through
-            // this rigamarole is so that developers don't have to rebuild the 
-            // installer as often (never, technically).
-
-            return Observable.Start(() => {
-                var fxVersion = determineFxVersionFromPackage(bundledPackageMetadata);
-                var eigenUpdater = new UpdateManager(currentAssemblyDir, bundledPackageMetadata.Id, fxVersion, targetRootDirectory);
-
-                var eigenCheckProgress = new Subject<int>();
-                var eigenCopyFileProgress = new Subject<int>();
-                var eigenApplyProgress = new Subject<int>();
-
-                var realCheckProgress = new Subject<int>();
-                var realCopyFileProgress = new Subject<int>();
-                var realApplyProgress = new Subject<int>();
-
-                // The real update takes longer than the eigenupdate because we're
-                // downloading from the Internet instead of doing everything 
-                // locally, so give it more weight
-                Observable.Concat(
-                        Observable.Concat(eigenCheckProgress, eigenCopyFileProgress, eigenCopyFileProgress).Select(x => (x / 3.0) * 0.33),
-                        Observable.Concat(realCheckProgress, realCopyFileProgress, realApplyProgress).Select(x => (x / 3.0) * 0.67))
-                    .Select(x => (int)x)
-                    .Subscribe(progress);
-
-                List<string> ret = null;
-                using (eigenUpdater.AcquireUpdateLock()) {
-                    ret = eigenUpdater.CheckForUpdate(progress: eigenCheckProgress)
-                        .SelectMany(x => eigenUpdater.DownloadReleases(x.ReleasesToApply, eigenCopyFileProgress).Select(_ => x))
-                        .SelectMany(x => eigenUpdater.ApplyReleases(x, eigenApplyProgress))
-                        .First();
-                }
-
-                var updateUrl = bundledPackageMetadata.ProjectUrl != null ? bundledPackageMetadata.ProjectUrl.ToString() : null;
-                var realUpdater = new UpdateManager(updateUrl, bundledPackageMetadata.Id, fxVersion, targetRootDirectory);
-
-                using (realUpdater.AcquireUpdateLock()) {
-                    realUpdater.CheckForUpdate(progress: realCheckProgress)
-                        .SelectMany(x => realUpdater.DownloadReleases(x.ReleasesToApply, realCopyFileProgress).Select(_ => x))
-                        .SelectMany(x => realUpdater.ApplyReleases(x, realApplyProgress))
-                        .LoggedCatch<List<string>, WixUiBootstrapper, Exception>(this, ex => {
-                            // NB: If we don't do this, we won't Collapse the Wave 
-                            // Function(tm) below on 'progress' and it will never complete
-                            realCheckProgress.OnError(ex);
-                            return Observable.Return(Enumerable.Empty<string>().ToList());
-                        }, "Failed to update to latest remote version")
-                        .First();
-                }
-
-                return ret;
-            }).ObserveOn(RxApp.DeferredScheduler);
-        }
-
-        IObservable<Unit> executeUninstall(string targetRootDirectory = null)
-        {
-            var updateManager = new UpdateManager("http://lol", BundledRelease.PackageName, FrameworkVersion.Net40, targetRootDirectory);
-
-            var updateLock = updateManager.AcquireUpdateLock();
-            return updateManager.FullUninstall()
-                .ObserveOn(RxApp.DeferredScheduler)
-                //.Log(this, "Full uninstall")  // XXX: Bug in RxUI 4
-                .Finally(updateLock.Dispose);
-        }
-
         UserError convertHResultToError(int status)
         {
             // NB: WiX passes this as an int which makes it impossible for us to
@@ -258,15 +179,7 @@ namespace Shimmer.WiXUi.ViewModels
         IPackage openBundledPackage()
         {
             var fi = fileSystem.GetFileInfo(Path.Combine(currentAssemblyDir, BundledRelease.Filename));
-
             return new ZipPackage(fi.FullName);
-        }
-
-        static FrameworkVersion determineFxVersionFromPackage(IPackage package)
-        {
-            return package.GetFiles().Any(x => x.Path.Contains("lib") && x.Path.Contains("45"))
-                ? FrameworkVersion.Net45
-                : FrameworkVersion.Net40;
         }
 
         ReleaseEntry readBundledReleasesFile()


### PR DESCRIPTION
This PR moves the actual "Install / Uninstall" logic into its own class in Shimmer.Client. This has the benefit of both being a Generally Good Idea™, as well as enabling people to write their own installers (or integrate with an existing installer UX), but still lay down a Shimmer installation.
