### PR TITLE
Bugfix - SHA1 checks should be case insenstive

### DIFF
--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -366,7 +366,7 @@ namespace Shimmer.Client
 
             using (var file = targetPackage.OpenRead()) {
                 var hash = Utility.CalculateStreamSHA1(file);
-                if (hash != downloadedRelease.SHA1) {
+                if (!hash.Equals(downloadedRelease.SHA1,StringComparison.OrdinalIgnoreCase)) {
                     log.Error("File SHA1 should be {0}, is {1}", downloadedRelease.SHA1, hash);
                     targetPackage.Delete();
                     throw new Exception("Checksum doesn't match: " + targetPackage.FullName);

--- a/src/Shimmer.Tests/Core/UtilityTests.cs
+++ b/src/Shimmer.Tests/Core/UtilityTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Shimmer.Core;
+using Shimmer.Tests.TestHelpers;
+using Xunit;
+
+namespace Shimmer.Tests.Core
+{
+    public class UtilityTests
+    {
+
+        [Fact]
+        public void ShaCheckShouldBeCaseInsensitive()
+        {
+            var sha1FromExternalTool = "75255cfd229a1ed1447abe1104f5635e69975d30";
+            var inputPackage = IntegrationTestHelper.GetPath("fixtures", "Shimmer.Core.1.0.0.0.nupkg");
+            var stream = File.OpenRead(inputPackage);
+            var sha1 = Utility.CalculateStreamSHA1(stream);
+
+            Assert.NotEqual(sha1FromExternalTool, sha1);
+            Assert.Equal(sha1FromExternalTool, sha1, StringComparer.OrdinalIgnoreCase);
+
+        }
+    }
+}

--- a/src/Shimmer.Tests/Shimmer.Tests.csproj
+++ b/src/Shimmer.Tests/Shimmer.Tests.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Core\DeltaPackageTests.cs" />
     <Compile Include="Core\ReleaseEntryTests.cs" />
     <Compile Include="Core\ReleasePackageTests.cs" />
+    <Compile Include="Core\UtilityTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StaticHttpServer.cs" />
     <Compile Include="TestHelpers\AssertExtensions.cs" />


### PR DESCRIPTION
Experimenting with setting up the infrastructure to craft an update feed and hit this issue.

If I generate the SHA1 from an external tool, it can have the letters as lower-case.

So I changed the check to be case-insenitive and added a test to demonstrate it.
