### PR TITLE
GetReleaseNotes will throw an exception when blank, empty, or null

### DIFF
--- a/src/CreateReleasePackage/CreateReleasePackage.csproj
+++ b/src/CreateReleasePackage/CreateReleasePackage.csproj
@@ -91,6 +91,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Mono.Options\Options.cs" />
+    <Compile Include="ParseCommands.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/CreateReleasePackage/ParseCommands.cs
+++ b/src/CreateReleasePackage/ParseCommands.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Mono.Options;
+using NuGet;
+
+namespace CreateReleasePackage
+{
+    public static class ParseCommands
+    {
+        public static Dictionary<string, string> ParseOptions(string[] args)
+        {
+            bool showHelp = false;
+            string targetDir = null;
+            string packagesDir = null;
+            string templateSource = null;
+
+            var opts = new OptionSet() {
+                { "p|packages-directory=", "(Optional) The NuGet packages directory to use, omit to use default", v => packagesDir = v },
+                { "o|output-directory=", "The target directory to put the generated file", v => targetDir = v },
+                { "preprocess-template=", "The template file to parse. Part of Create-Release.ps1, ignore this", v => templateSource = v },
+                { "h|help", "Show this message and exit", v => showHelp = v != null },
+            };
+
+            var filename = opts.Parse(args).FirstOrDefault();
+            showHelp = (String.IsNullOrEmpty(filename));
+
+            if (!File.Exists(filename)) {
+                Console.Error.WriteLine("'{0}' doesn't exist. Please specify an existing NuGet package", filename);
+                showHelp = true;
+            }
+
+            if (templateSource != null) {
+                Console.WriteLine((string) processTemplateFile(filename, templateSource));
+                return null;
+            }
+
+            if (String.IsNullOrEmpty(targetDir) || !Directory.Exists(targetDir)) {
+                Console.Error.WriteLine("'{0}' doesn't exist. Please specify an existing Release directory", filename);
+                showHelp = true;
+            }
+
+            if (!String.IsNullOrEmpty(packagesDir) && !Directory.Exists(packagesDir)) {
+                Console.Error.WriteLine("'{0}' doesn't exist. Please specify an existing packages directory", filename);
+                showHelp = true;
+            }
+
+            if (showHelp) {
+                Console.WriteLine("\nCreateReleasePackage - take a NuGet package and create a Release Package");
+                Console.WriteLine(@"Usage: CreateReleasePackage.exe [Options] \path\to\app.nupkg");
+
+                Console.WriteLine("Options:");
+                foreach(var v in opts) {
+                    if (v.GetNames().Length != 2) {
+                        Console.WriteLine("  --{0} - {1}", v.GetNames()[0], v.Description);
+                    } else {
+                        Console.WriteLine("  -{0}/--{1} - {2}", v.GetNames()[0], v.GetNames()[1], v.Description);
+                    }
+                }
+
+                return null;
+            }
+
+            return new Dictionary<string, string>() {
+                { "input", filename },
+                { "target", targetDir },
+                { "pkgdir", packagesDir ?? ""},
+            };
+        }
+
+        static string processTemplateFile(string packageFile, string templateFile)
+        {
+            var zp = new ZipPackage(packageFile);
+            var noBetaRegex = new Regex(@"-.*$");
+
+            checkIfNuspecHasRequiredFields(zp, packageFile);
+
+            var toSub = new[] {
+                new {Name = "Authors", Value = String.Join(", ", zp.Authors ?? Enumerable.Empty<string>())},
+                new {Name = "Description", Value = zp.Description},
+                new {Name = "IconUrl", Value = zp.IconUrl != null ? zp.IconUrl.ToString() : ""},
+                new {Name = "LicenseUrl", Value = zp.LicenseUrl != null ? zp.LicenseUrl.ToString() : ""},
+                new {Name = "ProjectUrl", Value = zp.ProjectUrl != null ? zp.ProjectUrl.ToString() : ""},
+                new {Name = "Summary", Value = zp.Summary ?? zp.Title },
+                new {Name = "Title", Value = zp.Title},
+                new {Name = "Version", Value = noBetaRegex.Replace(zp.Version.ToString(), "") },
+            };
+
+            var output = toSub.Aggregate(new StringBuilder(File.ReadAllText(templateFile)), (acc, x) =>
+                { acc.Replace(String.Format("$(var.NuGetPackage_{0})", x.Name), x.Value); return acc; });
+
+            var ret = Path.GetTempFileName();
+            File.WriteAllText(ret, output.ToString(), Encoding.UTF8);
+            return ret;
+        }
+
+        static void checkIfNuspecHasRequiredFields(IPackageMetadata zp, string packageFile)
+        {
+            if (String.IsNullOrWhiteSpace(zp.Id))
+                throw new Exception(String.Format("Invalid 'id' value in nuspec file at '{0}'", packageFile));
+
+            if (String.IsNullOrWhiteSpace(zp.Version.ToString()))
+                throw new Exception(String.Format("Invalid 'version' value in nuspec file at '{0}'", packageFile));
+
+            if (zp.Authors.All(String.IsNullOrWhiteSpace))
+                throw new Exception(String.Format("Invalid 'authors' value in nuspec file at '{0}'", zp.Authors));
+
+            if (String.IsNullOrWhiteSpace(zp.Description))
+                throw new Exception(String.Format("Invalid 'description' value in nuspec file at '{0}'", zp.Description));
+        }
+    }
+}

--- a/src/CreateReleasePackage/Program.cs
+++ b/src/CreateReleasePackage/Program.cs
@@ -1,22 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using MarkdownSharp;
-using Mono.Options;
-using NuGet;
 using Shimmer.Core;
 
 namespace CreateReleasePackage
 {
-    class Program
+    public class Program
     {
         static int Main(string[] args)
         {
-            var optParams = parseOptions(args);
+            var optParams = ParseCommands.ParseOptions(args);
             if (optParams == null) {
                 return -1;
             }
@@ -50,90 +45,6 @@ namespace CreateReleasePackage
 
             Console.WriteLine(fullRelease);
             return 0;
-        }
-
-        static Dictionary<string, string> parseOptions(string[] args)
-        {
-            bool showHelp = false;
-            string targetDir = null;
-            string packagesDir = null;
-            string templateSource = null;
-
-            var opts = new OptionSet() {
-                { "p|packages-directory=", "(Optional) The NuGet packages directory to use, omit to use default", v => packagesDir = v },
-                { "o|output-directory=", "The target directory to put the generated file", v => targetDir = v },
-                { "preprocess-template=", "The template file to parse. Part of Create-Release.ps1, ignore this", v => templateSource = v },
-                { "h|help", "Show this message and exit", v => showHelp = v != null },
-            };
-
-            var filename = opts.Parse(args).FirstOrDefault();
-            showHelp = (String.IsNullOrEmpty(filename));
-
-            if (!File.Exists(filename)) {
-                Console.Error.WriteLine("'{0}' doesn't exist. Please specify an existing NuGet package", filename);
-                showHelp = true;
-            }
-
-            if (templateSource != null) {
-                Console.WriteLine(processTemplateFile(filename, templateSource));
-                return null;
-            }
-
-            if (String.IsNullOrEmpty(targetDir) || !Directory.Exists(targetDir)) {
-                Console.Error.WriteLine("'{0}' doesn't exist. Please specify an existing Release directory", filename);
-                showHelp = true;
-            }
-
-            if (!String.IsNullOrEmpty(packagesDir) && !Directory.Exists(packagesDir)) {
-                Console.Error.WriteLine("'{0}' doesn't exist. Please specify an existing packages directory", filename);
-                showHelp = true;
-            }
-
-            if (showHelp) {
-                Console.WriteLine("\nCreateReleasePackage - take a NuGet package and create a Release Package");
-                Console.WriteLine(@"Usage: CreateReleasePackage.exe [Options] \path\to\app.nupkg");
-
-                Console.WriteLine("Options:");
-                foreach(var v in opts) {
-                    if (v.GetNames().Length != 2) {
-                        Console.WriteLine("  --{0} - {1}", v.GetNames()[0], v.Description);
-                    } else {
-                        Console.WriteLine("  -{0}/--{1} - {2}", v.GetNames()[0], v.GetNames()[1], v.Description);
-                    }
-                }
-
-                return null;
-            }
-
-            return new Dictionary<string, string>() {
-                { "input", filename },
-                { "target", targetDir },
-                { "pkgdir", packagesDir ?? ""},
-            };
-        }
-
-        static string processTemplateFile(string packageFile, string templateFile)
-        {
-            var zp = new ZipPackage(packageFile);
-            var noBetaRegex = new Regex(@"-.*$");
-
-            var toSub = new[] {
-                new {Name = "Authors", Value = String.Join(", ", zp.Authors ?? Enumerable.Empty<string>())},
-                new {Name = "Description", Value = zp.Description},
-                new {Name = "IconUrl", Value = zp.IconUrl != null ? zp.IconUrl.ToString() : ""},
-                new {Name = "LicenseUrl", Value = zp.LicenseUrl != null ? zp.LicenseUrl.ToString() : ""},
-                new {Name = "ProjectUrl", Value = zp.ProjectUrl != null ? zp.ProjectUrl.ToString() : ""},
-                new {Name = "Summary", Value = zp.Summary ?? zp.Title },
-                new {Name = "Title", Value = zp.Title},
-                new {Name = "Version", Value = noBetaRegex.Replace(zp.Version.ToString(), "") },
-            };
-
-            var output = toSub.Aggregate(new StringBuilder(File.ReadAllText(templateFile)), (acc, x) =>
-                { acc.Replace(String.Format("$(var.NuGetPackage_{0})", x.Name), x.Value); return acc; });
-
-            var ret = Path.GetTempFileName();
-            File.WriteAllText(ret, output.ToString(), Encoding.UTF8);
-            return ret;
         }
     }
 }

--- a/src/Shimmer.Core/ReleaseEntry.cs
+++ b/src/Shimmer.Core/ReleaseEntry.cs
@@ -85,6 +85,12 @@ namespace Shimmer.Core
         public string GetReleaseNotes(string packageDirectory)
         {
             var zp = new ZipPackage(Path.Combine(packageDirectory, Filename));
+
+            var t = zp.Id;
+
+            if (String.IsNullOrWhiteSpace(zp.ReleaseNotes))
+                throw new Exception(String.Format("Invalid 'ReleaseNotes' value in nuspec file at '{0}'", Path.Combine(packageDirectory, Filename)));
+
             return zp.ReleaseNotes;
         }
 

--- a/src/Shimmer.Tests/Core/ReleaseEntryTests.cs
+++ b/src/Shimmer.Tests/Core/ReleaseEntryTests.cs
@@ -56,5 +56,13 @@ namespace Shimmer.Tests.Core
             var entryAsString = ReleaseEntry.GenerateFromFile(path).EntryAsString;
             ReleaseEntry.ParseReleaseEntry(entryAsString);
         }
+
+        [Fact]
+        public void InvalidReleaseNotesThrowsException()
+        {
+            var path = IntegrationTestHelper.GetPath("fixtures", "Shimmer.Core.1.0.0.0.nupkg");
+            var fixture = ReleaseEntry.GenerateFromFile(path);
+            Assert.Throws<Exception>(() => fixture.GetReleaseNotes(IntegrationTestHelper.GetPath("fixtures")));
+        }
     }
 }

--- a/src/Shimmer.Tests/Release/ParseCommandsTests.cs
+++ b/src/Shimmer.Tests/Release/ParseCommandsTests.cs
@@ -1,0 +1,42 @@
+﻿using System.Reflection;
+using CreateReleasePackage;
+using NuGet;
+using ReactiveUI;
+using Shimmer.Tests.TestHelpers;
+using Xunit;
+
+namespace Shimmer.Tests.Release
+{
+    public class ParseCommandsTests : IEnableLogger
+    {
+        [Fact]
+        public void NuspecMissingRequiredFieldsThrowsExceptions()
+        {
+            var path = IntegrationTestHelper.GetPath("fixtures", "Shimmer.Core.1.1.0.0.nupkg");
+            var zp = new ZipPackage(path);
+
+            //Use reflection to grab an instance of the private method
+            var checkIfNuspecHasRequiredFields = typeof(ParseCommands).GetMethod("checkIfNuspecHasRequiredFields",
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+            zp.Id = "";
+            //Blank id exception
+            Assert.Throws<TargetInvocationException>(() => checkIfNuspecHasRequiredFields.Invoke(null, new object[] { zp, "Path" }));
+
+            zp.Id = "K";
+            //zp.Version = "";
+            //TODO: Test a blank version somehow
+            
+            //zp.Version = "1.0";
+            zp.Authors = new string[0];
+            //Blank authors exception
+            Assert.Throws<TargetInvocationException>(() => checkIfNuspecHasRequiredFields.Invoke(null, new object[] { zp, "Path" }));
+
+            zp.Authors = new[] { "AuthorName" };
+            zp.Description = "";
+            
+            //Blank description exception
+            Assert.Throws<TargetInvocationException>(() => checkIfNuspecHasRequiredFields.Invoke(null, new object[] { zp, "Path" }));
+        }
+    }
+}

--- a/src/Shimmer.Tests/Shimmer.Tests.csproj
+++ b/src/Shimmer.Tests/Shimmer.Tests.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Core\ReleaseEntryTests.cs" />
     <Compile Include="Core\ReleasePackageTests.cs" />
     <Compile Include="Core\UtilityTests.cs" />
+    <Compile Include="Release\ParseCommandsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StaticHttpServer.cs" />
     <Compile Include="TestHelpers\AssertExtensions.cs" />
@@ -186,6 +187,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CreateReleasePackage\CreateReleasePackage.csproj">
+      <Project>{DBC4253F-26BD-46D9-94E0-1413AB59613D}</Project>
+      <Name>CreateReleasePackage</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Shimmer.Client\Shimmer.Client.csproj">
       <Project>{f23cefd4-f1ba-4c37-a834-89a5e38055dd}</Project>
       <Name>Shimmer.Client</Name>


### PR DESCRIPTION
### Per conversation on twitter:

"One thing that really needs work is, Shimmer doesn't throw useful errors when devs don't do things right (i.e. if you have a missing entry in NuSpec) - would be great to get some friendly errors"

@xpaulbettsx: Is this the kind of thing your looking for? Exceptions if entries in the NuSpec file aren't filled in, or where you thinking something with checking to make sure the dependencies exist in the packages folder?
