### PR TITLE
Create Release Script

### DIFF
--- a/src/CreateReleasePackage/CreateReleasePackage.csproj
+++ b/src/CreateReleasePackage/CreateReleasePackage.csproj
@@ -69,10 +69,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NuGet.Core.2.7.0\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="ReactiveUI, Version=4.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\reactiveui-core.4.6.4\lib\Net40\ReactiveUI.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO">

--- a/src/CreateReleasePackage/Mono.Options/Options.cs
+++ b/src/CreateReleasePackage/Mono.Options/Options.cs
@@ -4,9 +4,11 @@
 // Authors:
 //  Jonathan Pryor <jpryor@novell.com>
 //  Federico Di Gregorio <fog@initd.org>
+//  Rolf Bjarne Kvinge <rolf@xamarin.com>
 //
 // Copyright (C) 2008 Novell (http://www.novell.com)
 // Copyright (C) 2009 Federico Di Gregorio.
+// Copyright (C) 2012 Xamarin Inc (http://www.xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -372,13 +374,19 @@ namespace Mono.Options
 		OptionValueType type;
 		int count;
 		string[] separators;
+		bool hidden;
 
 		protected Option (string prototype, string description)
-			: this (prototype, description, 1)
+			: this (prototype, description, 1, false)
 		{
 		}
 
 		protected Option (string prototype, string description, int maxValueCount)
+			: this (prototype, description, maxValueCount, false)
+		{
+		}
+
+		protected Option (string prototype, string description, int maxValueCount, bool hidden)
 		{
 			if (prototype == null)
 				throw new ArgumentNullException ("prototype");
@@ -400,6 +408,7 @@ namespace Mono.Options
 				return;
 
 			this.type        = ParsePrototype ();
+			this.hidden      = hidden;
 
 			if (this.count == 0 && type != OptionValueType.None)
 				throw new ArgumentException (
@@ -422,6 +431,7 @@ namespace Mono.Options
 		public string           Description     {get {return description;}}
 		public OptionValueType  OptionValueType {get {return type;}}
 		public int              MaxValueCount   {get {return count;}}
+		public bool             Hidden          {get {return hidden;}}
 
 		public string[] GetNames ()
 		{
@@ -805,7 +815,12 @@ namespace Mono.Options
 			Action<OptionValueCollection> action;
 
 			public ActionOption (string prototype, string description, int count, Action<OptionValueCollection> action)
-				: base (prototype, description, count)
+				: this (prototype, description, count, action, false)
+			{
+			}
+
+			public ActionOption (string prototype, string description, int count, Action<OptionValueCollection> action, bool hidden)
+				: base (prototype, description, count, hidden)
 			{
 				if (action == null)
 					throw new ArgumentNullException ("action");
@@ -825,10 +840,15 @@ namespace Mono.Options
 
 		public OptionSet Add (string prototype, string description, Action<string> action)
 		{
+			return Add (prototype, description, action, false);
+		}
+
+		public OptionSet Add (string prototype, string description, Action<string> action, bool hidden)
+		{
 			if (action == null)
 				throw new ArgumentNullException ("action");
 			Option p = new ActionOption (prototype, description, 1, 
-					delegate (OptionValueCollection v) { action (v [0]); });
+					delegate (OptionValueCollection v) { action (v [0]); }, hidden);
 			base.Add (p);
 			return this;
 		}
@@ -840,10 +860,14 @@ namespace Mono.Options
 
 		public OptionSet Add (string prototype, string description, OptionAction<string, string> action)
 		{
+			return Add (prototype, description, action, false);
+		}
+
+		public OptionSet Add (string prototype, string description, OptionAction<string, string> action, bool hidden)	{
 			if (action == null)
 				throw new ArgumentNullException ("action");
 			Option p = new ActionOption (prototype, description, 2, 
-					delegate (OptionValueCollection v) {action (v [0], v [1]);});
+					delegate (OptionValueCollection v) {action (v [0], v [1]);}, hidden);
 			base.Add (p);
 			return this;
 		}
@@ -1149,6 +1173,9 @@ namespace Mono.Options
 		{
 			foreach (Option p in this) {
 				int written = 0;
+
+				if (p.Hidden)
+					continue;
 
 				Category c = p as Category;
 				if (c != null) {

--- a/src/CreateReleasePackage/Properties/AssemblyInfo.cs
+++ b/src/CreateReleasePackage/Properties/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.4")]
-[assembly: AssemblyFileVersion("0.6.4")]
-[assembly: AssemblyInformationalVersion("0.6.4")]
+[assembly: AssemblyVersion("0.6.5")]
+[assembly: AssemblyFileVersion("0.6.5")]
+[assembly: AssemblyInformationalVersion("0.6.5")]

--- a/src/CreateReleasePackage/packages.config
+++ b/src/CreateReleasePackage/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.Bcl.Async" version="1.0.16" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="net40" />
   <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net40" />
+  <package id="Mono.Options" version="1.1" targetFramework="net40" developmentDependency="true" />
   <package id="NuGet.Core" version="2.7.0" targetFramework="net40" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net40" />

--- a/src/CreateReleasePackage/packages.config
+++ b/src/CreateReleasePackage/packages.config
@@ -6,7 +6,6 @@
   <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="net40" />
   <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net40" />
   <package id="NuGet.Core" version="2.7.0" targetFramework="net40" />
-  <package id="reactiveui-core" version="4.6.4" targetFramework="net40" allowedVersions="[4,5)" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net40" />

--- a/src/CreateReleasePackage/tools/Install.ps1
+++ b/src/CreateReleasePackage/tools/Install.ps1
@@ -31,4 +31,8 @@ function Initialize-Shimmer {
     $dte.ItemOperations.OpenFile($nuspecFile) | Out-Null
 }
 
+Write-Message "Now to setup the project - so you don't have to..."
+Write-Host
 Initialize-Shimmer
+Write-Host
+Write-Message "HEY! Don't forget to build the project before publishing!"

--- a/src/CreateReleasePackage/tools/Install.ps1
+++ b/src/CreateReleasePackage/tools/Install.ps1
@@ -1,3 +1,34 @@
 ﻿## http://stackoverflow.com/questions/5935162/nuget-error-external-packages-cannot-depend-on-packages-that-target-projects-w
 param($installPath, $toolsPath, $package, $project)
 $project.Object.Project.ProjectItems.Item("keep.me").Delete()
+
+Import-Module (Join-Path $toolsPath utilities.psm1)
+
+function Initialize-Shimmer {
+    [CmdletBinding()]
+    param (
+        [Parameter(Position=0, ValueFromPipeLine=$true)]
+        [string] $ProjectName = ''
+    )
+
+    if (-not $ProjectName) {
+        $ProjectName = (Get-Project).Name
+    }
+
+    $project = (Get-Project -Name $ProjectName)
+    $projectDir = (gci $project.FullName).Directory
+    $nuspecFile = (Join-Path $projectDir "$ProjectName.nuspec")
+
+    Write-Message "Initializing project $ProjectName for installer and packaging"
+
+    Add-InstallerTemplate -Destination $nuspecFile -ProjectName $ProjectName
+
+    Set-BuildPackage -Value $true -ProjectName $ProjectName
+
+    Add-FileWithNoOutput -FilePath $nuspecFile -Project $Project
+
+    # open the nuspec file in the editor
+    $dte.ItemOperations.OpenFile($nuspecFile) | Out-Null
+}
+
+Initialize-Shimmer

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -1,4 +1,6 @@
-﻿function Initialize-Installer {
+﻿$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+function Initialize-Installer {
     [CmdletBinding()]
     param (
         [Parameter(Position=0, ValueFromPipeLine=$true, Mandatory=$true)]
@@ -26,7 +28,13 @@ function Publish-Release {
         [string] $ProjectName = ''
     )
 
-    Write-Message "TODO: move the Powershell functionality into this project"
+	Write-Message "TODO: extract the solution directory from EnvDTE"
+	Write-Message "TODO: extract the build directory from EnvDTE (for the specific project)"
+	Write-Message "TODO: can we move that into the inner script?"
+
+    $createReleaseScript = Join-Path $toolsDir "Create-Release.ps1"
+
+    . $createReleaseScript -ProjectNameToBuild $ProjectName -SolutionDir . -BuildDirectory "bin\Release"
 }
 
 Export-ModuleMember Initialize-Installer

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -28,13 +28,16 @@ function Publish-Release {
         [string] $ProjectName = ''
     )
 
-	Write-Message "TODO: extract the solution directory from EnvDTE"
-	Write-Message "TODO: extract the build directory from EnvDTE (for the specific project)"
-	Write-Message "TODO: can we move that into the inner script?"
+    $solutionDir = (gci $dte.Solution.FullName).Directory
+
+    $project = Get-Project $ProjectName
+    $outputDir =  $project.ConfigurationManager.ActiveConfiguration.Properties.Item("OutputPath").Value
 
     $createReleaseScript = Join-Path $toolsDir "Create-Release.ps1"
 
-    . $createReleaseScript -ProjectNameToBuild $ProjectName -SolutionDir . -BuildDirectory "bin\Release"
+    . $createReleaseScript -ProjectNameToBuild $ProjectName  `
+                           -SolutionDir $solutionDir `
+                           -BuildDirectory $outputDir
 }
 
 Export-ModuleMember Initialize-Installer

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -1,33 +1,6 @@
 ﻿$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $createReleasePackageExe = Join-Path $toolsDir "CreateReleasePackage.exe"
     
-function Initialize-ProjectForShimmer {
-    [CmdletBinding()]
-    param (
-        [Parameter(Position=0, ValueFromPipeLine=$true)]
-        [string] $ProjectName = ''
-    )
-
-    if (-not $ProjectName) {
-        $ProjectName = (Get-Project).Name
-    }
-
-    $project = (Get-Project -Name $ProjectName)
-    $projectDir = (gci $project.FullName).Directory
-    $nuspecFile = (Join-Path $projectDir "$ProjectName.nuspec")
-
-    Write-Message "Initializing project $ProjectName for installer and packaging"
-
-    Add-InstallerTemplate -Destination $nuspecFile -ProjectName $ProjectName
-
-    Set-BuildPackage -Value $true -ProjectName $ProjectName
-
-    Add-FileWithNoOutput -FilePath $nuspecFile -Project $Project
-
-    # open the nuspec file in the editor
-    $dte.ItemOperations.OpenFile($nuspecFile) | Out-Null
-}
-
 function Generate-TemplateFromPackage {
     param(
         [Parameter(Mandatory = $true)]
@@ -88,8 +61,7 @@ function Create-ReleaseForProject {
 	}
 }
 
-
-function Publish-ShimmerRelease {
+function New-Release {
     [CmdletBinding()]
     param (
         [Parameter(Position=0, ValueFromPipeLine=$true)]
@@ -117,12 +89,8 @@ function Publish-ShimmerRelease {
                              -BuildDirectory (Join-Path $projectDir $outputDir)
 }
 
-# Statement completion for project names
-'Initialize-ProjectForShimmer', 'Publish-ShimmerRelease' | %{ 
-    Register-TabExpansion $_ @{
+Register-TabExpansion 'New-Release' @{
         ProjectName = { Get-Project -All | Select -ExpandProperty Name }
-    }
 }
 
-Export-ModuleMember Initialize-ProjectForShimmer
-Export-ModuleMember Publish-ShimmerRelease
+Export-ModuleMember New-Release

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -1,6 +1,6 @@
 ﻿$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
-function Initialize-Installer {
+function Initialize-ProjectForShimmer {
     [CmdletBinding()]
     param (
         [Parameter(Position=0, ValueFromPipeLine=$true)]
@@ -15,6 +15,8 @@ function Initialize-Installer {
     $projectDir = (gci $project.FullName).Directory
     $nuspecFile = (Join-Path $projectDir "$ProjectName.nuspec")
 
+    Write-Message "Initializing project $ProjectName for installer and packaging"
+
     Add-InstallerTemplate -Destination $nuspecFile -ProjectName $ProjectName
 
     Set-BuildPackage -Value $true -ProjectName $ProjectName
@@ -25,7 +27,7 @@ function Initialize-Installer {
     $dte.ItemOperations.OpenFile($nuspecFile) | Out-Null
 }
 
-function Publish-Release {
+function Publish-ShimmerRelease {
     [CmdletBinding()]
     param (
         [Parameter(Position=0, ValueFromPipeLine=$true)]
@@ -35,6 +37,8 @@ function Publish-Release {
     if (-not $ProjectName) {
         $ProjectName = (Get-Project).Name
     }
+
+    Write-Message "Publishing release for project $ProjectName"
 
     $solutionDir = (gci $dte.Solution.FullName).Directory
 
@@ -48,5 +52,12 @@ function Publish-Release {
                            -BuildDirectory $outputDir
 }
 
-Export-ModuleMember Initialize-Installer
-Export-ModuleMember Publish-Release
+# Statement completion for project names
+'Initialize-ProjectForShimmer', 'Publish-ShimmerRelease' | %{ 
+    Register-TabExpansion $_ @{
+        ProjectName = { Get-Project -All | Select -ExpandProperty Name }
+    }
+}
+
+Export-ModuleMember Initialize-ProjectForShimmer
+Export-ModuleMember Publish-ShimmerRelease

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -3,9 +3,13 @@
 function Initialize-Installer {
     [CmdletBinding()]
     param (
-        [Parameter(Position=0, ValueFromPipeLine=$true, Mandatory=$true)]
+        [Parameter(Position=0, ValueFromPipeLine=$true)]
         [string] $ProjectName = ''
     )
+
+    if (-not $ProjectName) {
+        $ProjectName = (Get-Project).Name
+    }
 
     $project = (Get-Project -Name $ProjectName)
     $projectDir = (gci $project.FullName).Directory
@@ -24,9 +28,13 @@ function Initialize-Installer {
 function Publish-Release {
     [CmdletBinding()]
     param (
-        [Parameter(Position=0, ValueFromPipeLine=$true, Mandatory=$true)]
-        [string] $ProjectName = ''
+        [Parameter(Position=0, ValueFromPipeLine=$true)]
+        [string] $ProjectName
     )
+
+    if (-not $ProjectName) {
+        $ProjectName = (Get-Project).Name
+    }
 
     $solutionDir = (gci $dte.Solution.FullName).Directory
 

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -24,12 +24,15 @@ function Create-ReleaseForProject {
 	$releaseDir = Join-Path $solutionDir "Releases"
 	if (!(Test-Path $releaseDir)) { mkdir -p $releaseDir }
 
-	echo "Creating Release for $solutionDir => $releaseDir`n"
+	Write-Message "Creating Release for $solutionDir => $releaseDir`n"
 
 	$nugetPackages = ls "$buildDirectory\*.nupkg" | ?{ $_.Name.EndsWith(".symbols.nupkg") -eq $false }
 
 	if ($nugetPackages.length -eq 0) {
-		throw "Shimmer couldn't find any .nupkg files in the folder $buildDirectory"
+		Write-Error "No .nupkg files were found in the build directory $buildDirectory"
+		Write-Error "Have you built the solution lately?"
+
+		return
 	}
 
 	foreach($pkg in $nugetPackages) {

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -1,5 +1,6 @@
 ﻿$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-
+$createReleasePackageExe = Join-Path $toolsDir "CreateReleasePackage.exe"
+    
 function Initialize-ProjectForShimmer {
     [CmdletBinding()]
     param (
@@ -27,12 +28,77 @@ function Initialize-ProjectForShimmer {
     $dte.ItemOperations.OpenFile($nuspecFile) | Out-Null
 }
 
+function Generate-TemplateFromPackage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$packageFile,
+        [Parameter(Mandatory = $true)]
+        [string]$templateFile
+    )
+
+	$resultFile = & $createReleasePackageExe --preprocess-template $templateFile $pkg.FullName
+    $resultFile
+}
+
+function Create-ReleaseForProject {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$solutionDir,
+		[Parameter(Mandatory = $true)]
+		[string]$buildDirectory
+	)
+
+	$releaseDir = Join-Path $solutionDir "Releases"
+	if (!(Test-Path $releaseDir)) { mkdir -p $releaseDir }
+
+	echo "Creating Release for $solutionDir => $releaseDir`n"
+
+	$nugetPackages = ls "$buildDirectory\*.nupkg" | ?{ $_.Name.EndsWith(".symbols.nupkg") -eq $false }
+
+	if ($nugetPackages.length -eq 0) {
+		throw "Shimmer couldn't find any .nupkg files in the folder $buildDirectory"
+	}
+
+	foreach($pkg in $nugetPackages) {
+        $pkgFullName = $pkg.FullName
+        echo "Found package $pkgFullName"
+
+		$packageDir = Join-Path $solutionDir "packages"
+		$fullRelease = & $createReleasePackageExe -o $releaseDir -p $packageDir $pkgFullName
+
+        ## NB: For absolutely zero reason whatsoever, $fullRelease ends up being the full path Three times
+        $fullRelease = $fullRelease.Split(" ")[0]
+		echo "Full release file at $fullRelease"
+
+        $candleTemplate = Generate-TemplateFromPackage $pkg.FullName "$toolsDir\template.wxs"
+        $wixTemplate = Join-Path $buildDirectory "template.wxs"
+        if (Test-Path $wixTemplate) { rm $wixTemplate | Out-Null }
+        mv $candleTemplate $wixTemplate | Out-Null
+
+		$defines = " -d`"ToolsDir=$toolsDir`"" + " -d`"NuGetFullPackage=$fullRelease`"" 
+
+		$candleExe = Join-Path $wixDir "candle.exe"
+		$lightExe = Join-Path $wixDir "light.exe"
+		
+		if (Test-Path "$buildDirectory\template.wixobj") {  rm "$buildDirectory\template.wixobj" | Out-Null }
+        echo "Running candle.exe"
+        & $candleExe "-d`"ToolsDir=$toolsDir`"" "-d`"ReleasesFile=$releaseDir\RELEASES`"" "-d`"NuGetFullPackage=$fullRelease`"" -out "$buildDirectory\template.wixobj" -arch x86 -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" $wixTemplate		
+        echo "Running light.exe"		
+        & $lightExe -out "$releaseDir\Setup.exe" -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$buildDirectory\template.wixobj"
+	}
+}
+
+
 function Publish-ShimmerRelease {
     [CmdletBinding()]
     param (
         [Parameter(Position=0, ValueFromPipeLine=$true)]
         [string] $ProjectName
     )
+
+    $wixDir = Join-Path $toolsDir "wix"
+    $support = Join-Path $toolsDir "support.ps1"
+    . $support
 
     if (-not $ProjectName) {
         $ProjectName = (Get-Project).Name
@@ -43,13 +109,12 @@ function Publish-ShimmerRelease {
     $solutionDir = (gci $dte.Solution.FullName).Directory
 
     $project = Get-Project $ProjectName
+
+    $projectDir = (gci $project.FullName).Directory
     $outputDir =  $project.ConfigurationManager.ActiveConfiguration.Properties.Item("OutputPath").Value
-
-    $createReleaseScript = Join-Path $toolsDir "Create-Release.ps1"
-
-    . $createReleaseScript -ProjectNameToBuild $ProjectName  `
-                           -SolutionDir $solutionDir `
-                           -BuildDirectory $outputDir
+    
+    Create-ReleaseForProject -SolutionDir $solutionDir `
+                             -BuildDirectory (Join-Path $projectDir $outputDir)
 }
 
 # Statement completion for project names

--- a/src/CreateReleasePackage/tools/utilities.psm1
+++ b/src/CreateReleasePackage/tools/utilities.psm1
@@ -126,19 +126,20 @@ function Add-FileWithNoOutput {
 
         # this is the evil code to make this all better
 
-        # let's use the native MSBuild object
-        # so we don't force a reload after install
-        $msbuildProj = Get-MSBuildProject $Project.Name
-        $xml = $msbuildProj.Xml
+        (Resolve-ProjectName $Project.Name) | %{
+            # use the native MSBuild object
+            $buildProject = $_ | Get-MSBuildProject
+         
+            # create the new elements with *just* the nuspec file
+            $itemGroup = $buildProject.Xml.AddItemGroup()
+            $none = $buildProject.Xml.CreateItemElement("None")
 
-        # create the new elements with *just* the nuspec file
-        $itemGroup = $xml.AddItemGroup()
-        $none = $xml.CreateItemElement("None")
+            $none.Include = $fileName
+            $itemGroup.AppendChild($none) | Out-Null
 
-        $none.Include = $fileName
-        $itemGroup.AppendChild($none) | Out-Null
-
-        $msbuildProj.Save()
+            # save the native project object instead
+            $_.Save()
+        }
 
         ###### end infinite crying
     } else {

--- a/src/CreateReleasePackage/tools/utilities.psm1
+++ b/src/CreateReleasePackage/tools/utilities.psm1
@@ -12,6 +12,16 @@ function Write-Message {
     Write-Host $Message
 }
 
+function Write-Error {
+    param(
+        [parameter(ValueFromPipelineByPropertyName = $true, Mandatory = $true)]
+        [string[]]$Message
+    )
+
+    Write-Host "Shimmer: " -f red -nonewline;
+    Write-Host $Message
+}
+
 function Resolve-ProjectName {
     param(
         [parameter(ValueFromPipelineByPropertyName = $true)]

--- a/src/CreateReleasePackage/tools/utilities.psm1
+++ b/src/CreateReleasePackage/tools/utilities.psm1
@@ -76,60 +76,51 @@ function Get-MSBuildProperty {
 
 function Get-ProjectItem {
     param(
-        [parameter(Position = 0, Mandatory = $true)]
+        [parameter(Position=0,ValueFromPipeLine=$true,Mandatory=$true)]
         $FileName,
-        [parameter(Position = 1, Mandatory = $true)]
-        $Project
+        [parameter(Position=1,ValueFromPipeLine=$true,Mandatory=$true)]
+        $ProjectName
     )
 
-    $existingFile = $Project.ProjectItems | Where-Object { $_.Name -eq $FileName }
+    (Resolve-ProjectName $ProjectName) | %{
 
-    if ($existingFile.length -eq 0) {
-        return $null
+        $existingFile = $_.ProjectItems | Where-Object { $_.Name -eq $FileName }
+
+        if ($existingFile.length -eq 0) {
+            $null
+        } else {
+            $existingFile[0]
+        }
     }
-
-    return $existingFile[0]
 }
 
 function Add-FileWithNoOutput {
     [CmdletBinding()]
     param (
-        [Parameter(Position=0, ValueFromPipeLine=$true, Mandatory=$true)]
+        [Parameter(Position=0,ValueFromPipeLine=$true,Mandatory=$true)]
         [string] $FilePath,
 
-        [Parameter(Position=1, ValueFromPipeLine=$true, Mandatory=$true)]
+        [Parameter(Position=1,ValueFromPipeLine=$true,Mandatory=$true)]
         $Project
     )
 
-    # do we have the existing file in the project?
     # NOTE: this won't work for nested files
     $fileName = (gci $FilePath).Name
-    $existingFile = Get-ProjectItem -FileName $fileName -Project $Project
+
+    # TODO: stop passing the Project object around
+    $projectName = $Project.Name
+
+    # do we have the existing file in the project?
+    $existingFile = Get-ProjectItem $fileName $projectName
 
     if ($existingFile -eq $null) {
-        Write-Message "Could not find file '$FilePath', adding it to project"
+        Write-Message "Could not find file '$FilePath' in project '$projectName'"
+        Write-Message "Adding nuspec file to the project"
 
-        ###### start infinite crying
-
-        # SO, have a guess at what this line of code is supposed to do
-        #
-        # $Project.DTE.ItemOperations.AddExistingItem($FilePath)
-        #
-        # Not sure? Well, according to MSDN (http://msdn.microsoft.com/en-us/library/envdte.itemoperations.addexistingitem(v=vs.110).aspx)
-        # it says "Adds an existing item to the current project." but
-        # my testing indicates it'll often just add it to the solution
-        # under a new Solution Folder, which isn't what I wanted either
-        # and after a few tries running this it'll add it to the
-        # project so I have two nuspec files in the solution.
-
-        # Fuck Yeah!
-
-        # this is the evil code to make this all better
-
-        (Resolve-ProjectName $Project.Name) | %{
+        (Resolve-ProjectName $projectName) | %{
             # use the native MSBuild object
             $buildProject = $_ | Get-MSBuildProject
-         
+
             # create the new elements with *just* the nuspec file
             $itemGroup = $buildProject.Xml.AddItemGroup()
             $none = $buildProject.Xml.CreateItemElement("None")
@@ -137,17 +128,15 @@ function Add-FileWithNoOutput {
             $none.Include = $fileName
             $itemGroup.AppendChild($none) | Out-Null
 
-            # save the native project object instead
+            # save the outer project object instead
             $_.Save()
         }
-
-        ###### end infinite crying
     } else {
         Write-Message "Ensuring nuspec file is excluded from build output"
 
         $copyToOutput = $existingFile.Properties.Item("CopyToOutputDirectory")
         $copyToOutput.Value = 0
-        $project.Save()
+        $Project.Save()
     }
 }
 

--- a/src/Shimmer.Client/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.Client/Properties/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.4")]
-[assembly: AssemblyFileVersion("0.6.4")]
-[assembly: AssemblyInformationalVersion("0.6.4")]
+[assembly: AssemblyVersion("0.6.5")]
+[assembly: AssemblyFileVersion("0.6.5")]
+[assembly: AssemblyInformationalVersion("0.6.5")]

--- a/src/Shimmer.Core/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.Core/Properties/AssemblyInfo.cs
@@ -30,8 +30,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.4")]
-[assembly: AssemblyFileVersion("0.6.4")]
-[assembly: AssemblyInformationalVersion("0.6.4")]
+[assembly: AssemblyVersion("0.6.5")]
+[assembly: AssemblyFileVersion("0.6.5")]
+[assembly: AssemblyInformationalVersion("0.6.5")]
 
 [assembly: InternalsVisibleTo("Shimmer.Client")]

--- a/src/Shimmer.Tests/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.Tests/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.4")]
-[assembly: AssemblyFileVersion("0.6.4")]
-[assembly: AssemblyInformationalVersion("0.6.4")]
+[assembly: AssemblyVersion("0.6.5")]
+[assembly: AssemblyFileVersion("0.6.5")]
+[assembly: AssemblyInformationalVersion("0.6.5")]

--- a/src/Shimmer.WiXUi/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.WiXUi/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using Shimmer.WiXUi;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.4")]
-[assembly: AssemblyFileVersion("0.6.4")]
-[assembly: AssemblyInformationalVersion("0.6.4")]
+[assembly: AssemblyVersion("0.6.5")]
+[assembly: AssemblyFileVersion("0.6.5")]
+[assembly: AssemblyInformationalVersion("0.6.5")]
 
 [assembly:BootstrapperApplication(typeof(App))]

--- a/src/Shimmer.WiXUiClient/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.WiXUiClient/Properties/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.4")]
-[assembly: AssemblyFileVersion("0.6.4")]
-[assembly: AssemblyInformationalVersion("0.6.4")]
+[assembly: AssemblyVersion("0.6.5")]
+[assembly: AssemblyFileVersion("0.6.5")]
+[assembly: AssemblyInformationalVersion("0.6.5")]


### PR DESCRIPTION
Resolves #53 

![screen shot 2013-08-29 at 11 38 51 am](https://f.cloud.github.com/assets/359239/1046834/dbbc1d00-104b-11e3-9d9d-1a4bc6456e6d.png)

Done:
- initialization now occurs when you install Shimmer, no manual steps needed
- renamed `Publish-ShimmerRelease` to `New-Release`
- tab-completion for places where you need a project name
- calling `Create-Release.ps1` to create the necessary package and installer
- when you don't specify a project, use the current one
- dropped RxUI core dependency for Shimmer (as per https://github.com/github/Shimmer/commit/fbbd3e6cbd6e60267fb9a98b4a0d08f21fe0781c#commitcomment-3959607)

TODO:
- [x] merge the `Create-Release.ps1` script into mine
- [x] update docs for changes to Powershell methods
- [x] auto-reload the csproj file, don't harass the user
- [x] update documentation
   - [x] better diagnostics based on edge cases (have you build the solution? etc)

(oh man i think i broke github-flavoured markdown - use your imagination on this one)

Open Questions:

~~Can you think of better names for the two methods above while using the approved `Get-Verb` syntax for Powershell methods - and indicating these are Shimmer-specific methods?~~ :boom: :metal: sorted
