### PR TITLE
Dropped ReactiveUI references from Shimmer.Client and Shimmer.Core

### DIFF
--- a/src/Shimmer.Client/Shimmer.Client.csproj
+++ b/src/Shimmer.Client/Shimmer.Client.csproj
@@ -92,9 +92,6 @@
       <HintPath>..\packages\NuGet.Core.2.7.0\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
-    <Reference Include="ReactiveUI">
-      <HintPath>..\packages\reactiveui-core.4.6.4\lib\Net40\ReactiveUI.dll</HintPath>
-    </Reference>
     <Reference Include="SharpBITS.Base, Version=2.0.0.0, Culture=neutral, PublicKeyToken=3f9d288a1b96f67a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\ext\SharpBITS.Base.dll</HintPath>

--- a/src/Shimmer.Client/packages.config
+++ b/src/Shimmer.Client/packages.config
@@ -5,7 +5,6 @@
   <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="net40" />
   <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net40" />
   <package id="NuGet.Core" version="2.7.0" targetFramework="net40" />
-  <package id="reactiveui-core" version="4.6.4" targetFramework="net40" allowedVersions="[4,5)" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net40" />

--- a/src/Shimmer.Core/Shimmer.Core.csproj
+++ b/src/Shimmer.Core/Shimmer.Core.csproj
@@ -89,9 +89,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NuGet.Core.2.7.0\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="ReactiveUI">
-      <HintPath>..\packages\reactiveui-core.4.6.4\lib\Net40\ReactiveUI.dll</HintPath>
-    </Reference>
     <Reference Include="SharpBITS.Base">
       <HintPath>..\..\ext\SharpBITS.Base.dll</HintPath>
     </Reference>

--- a/src/Shimmer.Core/packages.config
+++ b/src/Shimmer.Core/packages.config
@@ -5,7 +5,6 @@
   <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="net40" />
   <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net40" />
   <package id="NuGet.Core" version="2.7.0" targetFramework="net40" />
-  <package id="reactiveui-core" version="4.6.4" targetFramework="net40" allowedVersions="[4,5)" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net40" />


### PR DESCRIPTION
The [Shimmer.Client](http://www.nuget.org/packages/Shimmer.Client) and [Shimmer.Core](http://www.nuget.org/packages/Shimmer.Core) packages still have a reference to ReactiveUI although it isn't needed. I removed the reference so the NuGet package can be used with RxUI 5
