### PR TITLE
Added NuGet profiles to remove when creating a release

### DIFF
--- a/src/Shimmer.Core/ReleasePackage.cs
+++ b/src/Shimmer.Core/ReleasePackage.cs
@@ -72,7 +72,7 @@ namespace Shimmer.Core
                 var specPath = tempDir.GetFiles("*.nuspec").First().FullName;
 
                 removeDependenciesFromPackageSpec(specPath);
-                removeSilverlightAssemblies(tempDir);
+                removeNonDesktopAssemblies(tempDir);
                 removeDeveloperDocumentation(tempDir);
 
                 if (releaseNotesProcessor != null) {
@@ -118,15 +118,15 @@ namespace Shimmer.Core
                 .ForEach(x => x.Delete());
         }
 
-        void removeSilverlightAssemblies(DirectoryInfo expandedRepoPath)
+        void removeNonDesktopAssemblies(DirectoryInfo expandedRepoPath)
         {
-            // NB: Nuke Silverlight and WinRT. We can't tell as easily if other
-            // profiles can be removed because you can load net20 DLLs inside 
-            // .NET 4.0 apps
+            // NB: Nuke Silverlight, WinRT, WindowsPhone and Xamarin assemblies. 
+            // We can't tell as easily if other profiles can be removed because 
+            // you can load net20 DLLs inside .NET 4.0 apps
             var libPath = expandedRepoPath.GetDirectories().First(x => x.Name.ToLowerInvariant() == "lib");
             this.Log().Debug(libPath.FullName);
 
-            var bannedFrameworks = new[] {"sl", "winrt", "netcore", };
+            var bannedFrameworks = new[] {"sl", "winrt", "netcore", "win8", "windows8", "MonoAndroid", "MonoTouch", "MonoMac", "wp", };
 
             libPath.GetDirectories()
                 .Where(x => bannedFrameworks.Any(y => x.Name.ToLowerInvariant().StartsWith(y, StringComparison.InvariantCultureIgnoreCase)))

--- a/src/Shimmer.Tests/Core/ReleasePackageTests.cs
+++ b/src/Shimmer.Tests/Core/ReleasePackageTests.cs
@@ -36,10 +36,16 @@ namespace Shimmer.Tests.Core
                 refs.ShouldEqual(0);
 
                 this.Log().Info("Files in release package:");
-                pkg.GetFiles().ForEach(x => this.Log().Info(x.Path));
 
-                pkg.GetFiles().Any(x => x.Path.ToLowerInvariant().Contains(@"lib\sl")).ShouldBeFalse();
-                pkg.GetFiles().Any(x => x.Path.ToLowerInvariant().Contains(@".xml")).ShouldBeFalse();
+                List<IPackageFile> files = pkg.GetFiles().ToList();
+                files.ForEach(x => this.Log().Info(x.Path));
+
+                List<string> nonDesktopPaths = new[] {"sl", "winrt", "netcore", "win8", "windows8", "MonoAndroid", "MonoTouch", "MonoMac", "wp", }
+                    .Select(x => @"lib\" + x)
+                    .ToList();
+
+                files.Any(x => nonDesktopPaths.Any(y => x.Path.ToLowerInvariant().Contains(y.ToLowerInvariant()))).ShouldBeFalse();
+                files.Any(x => x.Path.ToLowerInvariant().Contains(@".xml")).ShouldBeFalse();
             } finally {
                 File.Delete(outputPackage);
             }


### PR DESCRIPTION
There are a few more profiles that can be safely removed, e.g Xamarin and Windows Phone, I've also added the remaining abbreviations for WinRT
