### PR TITLE
Remove obsolete framework profile check

### DIFF
--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -462,10 +462,6 @@ namespace Shimmer.Client
                 return false;
             }
 
-            if (packageFile.Path.StartsWith("lib\\winrt45", StringComparison.InvariantCultureIgnoreCase)) {
-                return false;
-            }
-
             return true;
         }
 


### PR DESCRIPTION
Non-Desktop profiles are removed on package creation, so a WinRT profile
will never happen.
