### PR TITLE
CreateReleasePackage should not be a project reference

### DIFF
--- a/Create-Release.ps1
+++ b/Create-Release.ps1
@@ -20,6 +20,15 @@ if ($BumpVersion) {
 }
 . $rootFolder\Build-Solution.ps1 -Build $build -Config $config
 
+Write-Host ""
+Write-Host "Because of a limitation in the auto-generated NuGet package"
+Write-Host "I need to re-compile the CreateReleasePackage tool now"
+Write-Host "passing the magic parameter -Tool so that the project reference"
+Write-Host "goes away"
+WRite-Host ""
+
+. $rootFolder\src\.nuget\NuGet.exe pack $rootFolder\src\CreateReleasePackage\CreateReleasePackage.csproj -Tool -OutputDirectory $rootFolder\bin\
+
 if (Test-Path $binaries) {
     Remove-Item "$rootFolder\bin\Shimmer.Tests.*.nupkg"
     Remove-Item "$rootFolder\bin\Shimmer.WiXUi.*.nupkg"

--- a/src/CreateReleasePackage/CreateReleasePackage.nuspec
+++ b/src/CreateReleasePackage/CreateReleasePackage.nuspec
@@ -26,7 +26,6 @@
 
     <file src="keep.me" target="content" />
 
-    <file src="..\..\bin\CreateReleasePackage.exe" target="tools" />
     <file src="..\..\bin\Ionic.Zip.dll" target="tools" />
     <file src="..\..\bin\MarkdownSharp.dll" target="tools" />
     <file src="..\..\bin\NuGet.Core.dll" target="tools" />

--- a/src/CreateReleasePackage/Properties/AssemblyInfo.cs
+++ b/src/CreateReleasePackage/Properties/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.8")]
-[assembly: AssemblyFileVersion("0.6.8")]
-[assembly: AssemblyInformationalVersion("0.6.8")]
+[assembly: AssemblyVersion("0.6.9")]
+[assembly: AssemblyFileVersion("0.6.9")]
+[assembly: AssemblyInformationalVersion("0.6.9")]

--- a/src/Shimmer.Client/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.Client/Properties/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.8")]
-[assembly: AssemblyFileVersion("0.6.8")]
-[assembly: AssemblyInformationalVersion("0.6.8")]
+[assembly: AssemblyVersion("0.6.9")]
+[assembly: AssemblyFileVersion("0.6.9")]
+[assembly: AssemblyInformationalVersion("0.6.9")]

--- a/src/Shimmer.Core/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.Core/Properties/AssemblyInfo.cs
@@ -30,8 +30,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.8")]
-[assembly: AssemblyFileVersion("0.6.8")]
-[assembly: AssemblyInformationalVersion("0.6.8")]
+[assembly: AssemblyVersion("0.6.9")]
+[assembly: AssemblyFileVersion("0.6.9")]
+[assembly: AssemblyInformationalVersion("0.6.9")]
 
 [assembly: InternalsVisibleTo("Shimmer.Client")]

--- a/src/Shimmer.Tests/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.Tests/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.8")]
-[assembly: AssemblyFileVersion("0.6.8")]
-[assembly: AssemblyInformationalVersion("0.6.8")]
+[assembly: AssemblyVersion("0.6.9")]
+[assembly: AssemblyFileVersion("0.6.9")]
+[assembly: AssemblyInformationalVersion("0.6.9")]

--- a/src/Shimmer.WiXUi/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.WiXUi/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using Shimmer.WiXUi;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.8")]
-[assembly: AssemblyFileVersion("0.6.8")]
-[assembly: AssemblyInformationalVersion("0.6.8")]
+[assembly: AssemblyVersion("0.6.9")]
+[assembly: AssemblyFileVersion("0.6.9")]
+[assembly: AssemblyInformationalVersion("0.6.9")]
 
 [assembly:BootstrapperApplication(typeof(App))]

--- a/src/Shimmer.WiXUiClient/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.WiXUiClient/Properties/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.8")]
-[assembly: AssemblyFileVersion("0.6.8")]
-[assembly: AssemblyInformationalVersion("0.6.8")]
+[assembly: AssemblyVersion("0.6.9")]
+[assembly: AssemblyFileVersion("0.6.9")]
+[assembly: AssemblyInformationalVersion("0.6.9")]


### PR DESCRIPTION
Resolves #77 

Before:
- **Shimmer.0.6.8-beta** has file `lib/net40/CreateReleasePackage.exe` as well as `tools/CreateReleasePackage.exe`

After
- `lib` folder is removed
