### PR TITLE
Releases hotfixes

### DIFF
--- a/src/CreateReleasePackage/Program.cs
+++ b/src/CreateReleasePackage/Program.cs
@@ -35,6 +35,10 @@ namespace CreateReleasePackage
             if (File.Exists(releaseFile)) {
                 var releaseEntries = ReleaseEntry.ParseReleaseFile(File.ReadAllText(releaseFile, Encoding.UTF8));
 
+                // TODO: when I call this with an existing release
+                // it should iterate over all the releases
+                // *before* this current version
+
                 var latestFullRelease = releaseEntries
                     .Where(x => x.IsDelta == false)
                     .MaxBy(x => x.Version)
@@ -49,7 +53,6 @@ namespace CreateReleasePackage
             }
                 
             ReleaseEntry.BuildReleasesFile(targetDir);
-
 
             return 0;
         }

--- a/src/CreateReleasePackage/Program.cs
+++ b/src/CreateReleasePackage/Program.cs
@@ -35,23 +35,22 @@ namespace CreateReleasePackage
             if (File.Exists(releaseFile)) {
                 var releaseEntries = ReleaseEntry.ParseReleaseFile(File.ReadAllText(releaseFile, Encoding.UTF8));
 
-                // TODO: when I call this with an existing release
-                // it should iterate over all the releases
-                // *before* this current version
-
-                var latestFullRelease = releaseEntries
+                var previousFullRelease = releaseEntries
                     .Where(x => x.IsDelta == false)
+                    .Where(x => x.Version < package.Version)
                     .MaxBy(x => x.Version)
                     .Select(x => new ReleasePackage(Path.Combine(targetDir, x.Filename), true))
                     .FirstOrDefault();
 
-                var deltaFile = Path.Combine(targetDir, package.SuggestedReleaseFileName.Replace("full", "delta"));
-                Console.WriteLine("{0}; {1}", latestFullRelease.InputPackageFile, deltaFile);
+                if (previousFullRelease != null) {
+                    var deltaFile = Path.Combine(targetDir, package.SuggestedReleaseFileName.Replace("full", "delta"));
+                    Console.WriteLine("{0}; {1}", previousFullRelease.InputPackageFile, deltaFile);
 
-                var deltaBuilder = new DeltaPackageBuilder();
-                deltaBuilder.CreateDeltaPackage(package, latestFullRelease, deltaFile);
+                    var deltaBuilder = new DeltaPackageBuilder();
+                    deltaBuilder.CreateDeltaPackage(previousFullRelease, package, deltaFile);
+                }
             }
-                
+
             ReleaseEntry.BuildReleasesFile(targetDir);
 
             return 0;

--- a/src/CreateReleasePackage/Properties/AssemblyInfo.cs
+++ b/src/CreateReleasePackage/Properties/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.9")]
-[assembly: AssemblyFileVersion("0.6.9")]
-[assembly: AssemblyInformationalVersion("0.6.9")]
+[assembly: AssemblyVersion("0.6.10")]
+[assembly: AssemblyFileVersion("0.6.10")]
+[assembly: AssemblyInformationalVersion("0.6.10")]

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -35,7 +35,9 @@ function Create-ReleaseForProject {
 
     Write-Message "Checking $buildDirectory for packages`n"
 
-    $nugetPackages = ls "$buildDirectory\*.nupkg" | ?{ $_.Name.EndsWith(".symbols.nupkg") -eq $false }
+    $nugetPackages = ls "$buildDirectory\*.nupkg" `
+        | ?{ $_.Name.EndsWith(".symbols.nupkg") -eq $false } `
+        | sort @{expression={$_.LastWriteTime};Descending=$false}
 
     if ($nugetPackages.length -eq 0) {
         Write-Error "No .nupkg files were found in the build directory"

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -56,13 +56,13 @@ function Create-ReleaseForProject {
 
     foreach($pkg in $nugetPackages) {
         $pkgFullName = $pkg.FullName
-
-		$packageDir = Join-Path $solutionDir "packages"
-		$releaseOutput = & $createReleasePackageExe -o $releaseDir -p $packageDir $pkgFullName
+       
+        $packageDir = Join-Path $solutionDir "packages"
+        $releaseOutput = & $createReleasePackageExe -o $releaseDir -p $packageDir $pkgFullName
 
         $packages = $releaseOutput.Split(";")
-
         $fullRelease = $packages[0]
+
         Write-Host ""
         Write-Message "Full release: $fullRelease"
 

--- a/src/Shimmer.Client/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.Client/Properties/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.9")]
-[assembly: AssemblyFileVersion("0.6.9")]
-[assembly: AssemblyInformationalVersion("0.6.9")]
+[assembly: AssemblyVersion("0.6.10")]
+[assembly: AssemblyFileVersion("0.6.10")]
+[assembly: AssemblyInformationalVersion("0.6.10")]

--- a/src/Shimmer.Core/DeltaPackage.cs
+++ b/src/Shimmer.Core/DeltaPackage.cs
@@ -23,6 +23,14 @@ namespace Shimmer.Core
             Contract.Requires(basePackage != null && basePackage.ReleasePackageFile != null);
             Contract.Requires(!String.IsNullOrEmpty(outputFile) && !File.Exists(outputFile));
 
+            if (basePackage.Version > newPackage.Version) {
+                var message = String.Format(
+                    "You cannot create a delta package based on version {0} as it is a later version than {1}",
+                    basePackage.Version,
+                    newPackage.Version);
+                throw new InvalidOperationException(message);
+            }
+
             string baseTempPath = null;
             string tempPath = null;
 

--- a/src/Shimmer.Core/Extensions/ReleaseExtensions.cs
+++ b/src/Shimmer.Core/Extensions/ReleaseExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Shimmer.Core.Extensions
+{
+    public static class VersionExtensions
+    {
+        public static Version ToVersion(this string fileName)
+        {
+            var parts = (new FileInfo(fileName)).Name
+                    .Replace(".nupkg", "").Replace("-delta", "")
+                    .Split('.', '-').Reverse();
+
+            var numberRegex = new Regex(@"^\d+$");
+
+            var versionFields = parts
+                .Where(x => numberRegex.IsMatch(x))
+                .Select(Int32.Parse)
+                .Reverse()
+                .ToArray();
+
+            if (versionFields.Length < 2 || versionFields.Length > 4)
+            {
+                return null;
+            }
+
+            switch (versionFields.Length)
+            {
+                case 2:
+                    return new Version(versionFields[0], versionFields[1]);
+                case 3:
+                    return new Version(versionFields[0], versionFields[1], versionFields[2]);
+                case 4:
+                    return new Version(versionFields[0], versionFields[1], versionFields[2], versionFields[3]);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Shimmer.Core/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.Core/Properties/AssemblyInfo.cs
@@ -30,8 +30,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.9")]
-[assembly: AssemblyFileVersion("0.6.9")]
-[assembly: AssemblyInformationalVersion("0.6.9")]
+[assembly: AssemblyVersion("0.6.10")]
+[assembly: AssemblyFileVersion("0.6.10")]
+[assembly: AssemblyInformationalVersion("0.6.10")]
 
 [assembly: InternalsVisibleTo("Shimmer.Client")]

--- a/src/Shimmer.Core/ReleaseEntry.cs
+++ b/src/Shimmer.Core/ReleaseEntry.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using NuGet;
 using ReactiveUIMicro;
+using Shimmer.Core.Extensions;
 
 namespace Shimmer.Core
 {
@@ -45,36 +46,7 @@ namespace Shimmer.Core
             get { return String.Format("{0} {1} {2}", SHA1, Filename, Filesize); } 
         }
 
-        public Version Version {
-            get {
-                var parts = (new FileInfo(Filename)).Name
-                    .Replace(".nupkg", "").Replace("-delta", "")
-                    .Split('.', '-').Reverse();
-
-                var numberRegex = new Regex(@"^\d+$");
-
-                var versionFields = parts
-                    .Where(x => numberRegex.IsMatch(x))
-                    .Select(Int32.Parse)
-                    .Reverse()
-                    .ToArray();
-
-                if (versionFields.Length < 2 || versionFields.Length > 4) {
-                    return null;
-                }
-
-                switch(versionFields.Length) {
-                case 2:
-                    return new Version(versionFields[0], versionFields[1]);
-                case 3:
-                    return new Version(versionFields[0], versionFields[1], versionFields[2]);
-                case 4:
-                    return new Version(versionFields[0], versionFields[1], versionFields[2], versionFields[3]);
-                }
-
-                return null;
-            } 
-        }
+        public Version Version { get { return Filename.ToVersion(); } }
 
         public string PackageName {
             get {

--- a/src/Shimmer.Core/ReleasePackage.cs
+++ b/src/Shimmer.Core/ReleasePackage.cs
@@ -12,6 +12,7 @@ using System.Xml;
 using Ionic.Zip;
 using NuGet;
 using ReactiveUIMicro;
+using Shimmer.Core.Extensions;
 
 namespace Shimmer.Core
 {
@@ -44,6 +45,8 @@ namespace Shimmer.Core
                 return String.Format("{0}-{1}-full.nupkg", zp.Id, zp.Version);
             }
         }
+
+        public Version Version { get { return InputPackageFile.ToVersion(); } }
 
         public string CreateReleasePackage(string outputFile, string packagesRootDir = null, Func<string, string> releaseNotesProcessor = null)
         {

--- a/src/Shimmer.Core/Shimmer.Core.csproj
+++ b/src/Shimmer.Core/Shimmer.Core.csproj
@@ -135,6 +135,7 @@
     <Compile Include="DeltaPackage.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\PackageExtensions.cs" />
+    <Compile Include="Extensions\ReleaseExtensions.cs" />
     <Compile Include="Http.cs" />
     <Compile Include="IFileSystemFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Shimmer.Tests/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.Tests/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.9")]
-[assembly: AssemblyFileVersion("0.6.9")]
-[assembly: AssemblyInformationalVersion("0.6.9")]
+[assembly: AssemblyVersion("0.6.10")]
+[assembly: AssemblyFileVersion("0.6.10")]
+[assembly: AssemblyInformationalVersion("0.6.10")]

--- a/src/Shimmer.WiXUi/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.WiXUi/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using Shimmer.WiXUi;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.9")]
-[assembly: AssemblyFileVersion("0.6.9")]
-[assembly: AssemblyInformationalVersion("0.6.9")]
+[assembly: AssemblyVersion("0.6.10")]
+[assembly: AssemblyFileVersion("0.6.10")]
+[assembly: AssemblyInformationalVersion("0.6.10")]
 
 [assembly:BootstrapperApplication(typeof(App))]

--- a/src/Shimmer.WiXUi/Shimmer.WiXUi.csproj
+++ b/src/Shimmer.WiXUi/Shimmer.WiXUi.csproj
@@ -31,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>649</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BootstrapperCore, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">

--- a/src/Shimmer.WiXUiClient/Properties/AssemblyInfo.cs
+++ b/src/Shimmer.WiXUiClient/Properties/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.9")]
-[assembly: AssemblyFileVersion("0.6.9")]
-[assembly: AssemblyInformationalVersion("0.6.9")]
+[assembly: AssemblyVersion("0.6.10")]
+[assembly: AssemblyFileVersion("0.6.10")]
+[assembly: AssemblyInformationalVersion("0.6.10")]


### PR DESCRIPTION
Fixes:
- Resolves #76 - installer created once (using latest version) and has latest package
- Resolves #70 - when delta packages cannot be found, try again without using delta packages
- packages found in build output are now sorted by date written (not by name)
- delta package creation now checks that the base package is earlier than the new package
