### PR TITLE
Deprecate MaxBy when scanning the contents of RELEASES

### DIFF
--- a/src/Shimmer.Core/Extensions/ReleaseExtensions.cs
+++ b/src/Shimmer.Core/Extensions/ReleaseExtensions.cs
@@ -9,6 +9,11 @@ namespace Shimmer.Core.Extensions
 {
     public static class VersionExtensions
     {
+        public static Version ToVersion(this IReleasePackage package)
+        {
+            return package.InputPackageFile.ToVersion();
+        }
+
         public static Version ToVersion(this string fileName)
         {
             var parts = (new FileInfo(fileName)).Name

--- a/src/Shimmer.Core/ReleaseEntry.cs
+++ b/src/Shimmer.Core/ReleaseEntry.cs
@@ -173,5 +173,18 @@ namespace Shimmer.Core
         {
             return filename.EndsWith("-delta.nupkg", StringComparison.InvariantCultureIgnoreCase);
         }
+
+        public static ReleasePackage GetPreviousRelease(IEnumerable<ReleaseEntry> releaseEntries, IReleasePackage package, string targetDir)
+        {
+            if (releaseEntries == null || !releaseEntries.Any())
+                return null;
+
+            return releaseEntries
+                    .Where(x => x.IsDelta == false)
+                    .Where(x => x.Version < package.ToVersion())
+                    .OrderByDescending(x => x.Version)
+                    .Select(x => new ReleasePackage(Path.Combine(targetDir, x.Filename), true))
+                    .FirstOrDefault();
+        }
     }
 }


### PR DESCRIPTION
Resolves #83 

Getting this code:

```
var previousFullRelease = releaseEntries
    .Where(x => x.IsDelta == false)
    .Where(x => x.Version < package.Version)
    .MaxBy(x => x.Version)
    .Select(x => new ReleasePackage(Path.Combine(targetDir, x.Filename), true))
    .FirstOrDefault();
```

under test to isolate a bug where _sometimes_ it would spit errors (without helpful context).
- moved this under `ReleaseEntry` so that it could be testable outside `Program.cs`
- captured various edge cases as unit tests
