### PR TITLE
Don't blow up if somebody deletes the app directory before an uninstall

### DIFF
--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -175,6 +175,10 @@ namespace Shimmer.Core
         {
             var di = new DirectoryInfo(directoryPath);
 
+            if (!di.Exists) {
+                return;
+            }
+
             // NB: MoveFileEx blows up if you're a non-admin, so you always need a backup plan
             di.GetFiles().ForEach(x => safeDeleteFileAtNextDir(x.FullName));
             di.GetDirectories().ForEach(x => DeleteDirectoryAtNextReboot(x.FullName));

--- a/src/Shimmer.Tests/Client/InstallManagerTests.cs
+++ b/src/Shimmer.Tests/Client/InstallManagerTests.cs
@@ -105,5 +105,23 @@ namespace Shimmer.Tests.Client
                 di.GetFiles().Any().ShouldBeFalse();
             }
         }
+
+        [Fact]
+        public void UninstallDoesntCrashOnMissingAppDirectory()
+        {
+            string dir;
+            string appDir;
+            InstallManager fixture;
+
+            using (IntegrationTestHelper.WithFakeInstallDirectory(out dir))
+            using (IntegrationTestHelper.WithFakeAlreadyInstalledApp(out appDir)) {
+                var di = new DirectoryInfo(dir);
+
+                var bundledRelease = ReleaseEntry.GenerateFromFile(di.GetFiles("*.nupkg").First().FullName);
+                fixture = new InstallManager(bundledRelease, appDir);
+            }
+            
+            fixture.ExecuteUninstall().First();
+        }
     }
 }


### PR DESCRIPTION
If the user deleted the app directory for what reason ever, the uninstaller previously crashed.
