### PR TITLE
Don't check in the contract if the directory exists

### DIFF
--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -133,7 +133,7 @@ namespace Shimmer.Core
 
         public static void DeleteDirectory(string directoryPath)
         {
-            Contract.Requires(!String.IsNullOrEmpty(directoryPath) && Directory.Exists(directoryPath));
+            Contract.Requires(!String.IsNullOrEmpty(directoryPath));
 
             if (!Directory.Exists(directoryPath)) {
                 LogManager.GetLogger(typeof(Utility))


### PR DESCRIPTION
In 24927735df73c9d7960f65302cc5b738b8cdd5e3 we return if a directory
doesn't exist, but it would throw at the contract check.
