### PR TITLE
Test all the Update Things

### DIFF
--- a/src/Shimmer.Client/InstallerHookOperations.cs
+++ b/src/Shimmer.Client/InstallerHookOperations.cs
@@ -145,7 +145,7 @@ namespace Shimmer.Client
                 // NB: This can happen if we run into a MoveFileEx'd directory,
                 // where we can't even get the list of files in it.
                 log.WarnException("Couldn't search directory for IAppSetups: " + appDirectory, ex);
-                throw;
+                return Enumerable.Empty<IAppSetup>();
             }
 
             var locatedAppSetups = allExeFiles

--- a/src/Shimmer.Client/InstallerHookOperations.cs
+++ b/src/Shimmer.Client/InstallerHookOperations.cs
@@ -16,9 +16,11 @@ namespace Shimmer.Client
         readonly IFileSystemFactory fileSystem;
         readonly string applicationName;
 
-        public InstallerHookOperations(IRxUIFullLogger log, IFileSystemFactory fileSystem, string applicationName)
+        public InstallerHookOperations(IFileSystemFactory fileSystem, string applicationName)
         {
-            this.log = log;
+            // XXX: ALWAYS BE LOGGING
+            this.log = new WrappingFullLogger(new FileLogger(applicationName), typeof(InstallerHookOperations));
+            
             this.fileSystem = fileSystem;
             this.applicationName = applicationName;
         }

--- a/src/Shimmer.Client/InstallerHookOperations.cs
+++ b/src/Shimmer.Client/InstallerHookOperations.cs
@@ -81,11 +81,13 @@ namespace Shimmer.Client
             return shortcuts.Aggregate(new List<ShortcutCreationRequest>(), (acc, x) => {
                 var path = x.GetLinkTarget(applicationName);
                 var fi = fileSystem.GetFileInfo(path);
-	    
+
                 if (fi.Exists) {
                     fi.Delete();
+                    log.Info("Deleting shortcut: {0}", fi.FullName);
                 } else {
                     acc.Add(x);
+                    log.Info("Shortcut not found: {0}, capturing for future reference", fi.FullName);
                 }
                 
                 return acc;
@@ -116,11 +118,17 @@ namespace Shimmer.Client
                     var shortcut = x.GetLinkTarget(applicationName, true);
 
                     var fi = fileSystem.GetFileInfo(shortcut);
-                    if (fi.Exists) fi.Delete();
+
+                    log.Info("installAppVersion: checking shortcut {0}", fi.FullName);
+
+                    if (fi.Exists) {
+                        log.Info("installAppVersion: deleting existing file");
+                        fi.Delete();
+                    }
 
                     fileSystem.CreateDirectoryRecursive(fi.Directory.FullName);
 
-                    var sl = new ShellLink() {
+                    var sl = new ShellLink {
                         Target = x.TargetPath,
                         IconPath = x.IconLibrary,
                         IconIndex = x.IconIndex,

--- a/src/Shimmer.Client/InstallerHookOperations.cs
+++ b/src/Shimmer.Client/InstallerHookOperations.cs
@@ -97,7 +97,11 @@ namespace Shimmer.Client
         string installAppVersion(IAppSetup app, Version newCurrentVersion, IEnumerable<ShortcutCreationRequest> shortcutRequestsToIgnore, bool isFirstInstall)
         {
             try {
-                if (isFirstInstall) app.OnAppInstall();
+                if (isFirstInstall) {
+                    log.Info("installAppVersion: Doing first install for {0}", app.Target);
+                    app.OnAppInstall();
+                }
+                log.Info("installAppVersion: Doing install for version {0} {1}", newCurrentVersion, app.Target);
                 app.OnVersionInstalled(newCurrentVersion);
             } catch (Exception ex) {
                 log.ErrorException("App threw exception on install:  " + app.GetType().FullName, ex);
@@ -107,6 +111,8 @@ namespace Shimmer.Client
             var shortcutList = Enumerable.Empty<ShortcutCreationRequest>();
             try {
                 shortcutList = app.GetAppShortcutList();
+                shortcutList.ForEach(x =>
+                    log.Info("installAppVersion: we have a shortcut {0}", x.TargetPath));
             } catch (Exception ex) {
                 log.ErrorException("App threw exception on shortcut uninstall:  " + app.GetType().FullName, ex);
                 throw;

--- a/src/Shimmer.Client/InstallerHookOperations.cs
+++ b/src/Shimmer.Client/InstallerHookOperations.cs
@@ -162,11 +162,14 @@ namespace Shimmer.Client
                 .Select(createInstanceOrWhine).Where(x => x != null)
                 .ToArray();
 
-            return locatedAppSetups.Length > 0
-                ? locatedAppSetups
-                : allExeFiles.Select(x => new DidntFollowInstructionsAppSetup(x.FullName)).ToArray();
+            if (!locatedAppSetups.Any()) {
+                log.Warn("Could not find any AppSetup instances");
+                allExeFiles.ForEach(f => log.Info("We have an exe: {0}", f.FullName));
+                return allExeFiles.Select(x => new DidntFollowInstructionsAppSetup(x.FullName))
+                                  .ToArray();
+            }
+            return locatedAppSetups;
         }
-
 
         IAppSetup createInstanceOrWhine(Type typeToCreate)
         {

--- a/src/Shimmer.Client/Shimmer.Client.csproj
+++ b/src/Shimmer.Client/Shimmer.Client.csproj
@@ -71,10 +71,6 @@
     <Reference Include="BootstrapperCore">
       <HintPath>..\..\ext\wix\sdk\BootstrapperCore.dll</HintPath>
     </Reference>
-    <Reference Include="Ionic.Zip, Version=1.9.1.8, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\ext\Ionic.Zip.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Threading.Tasks">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.16\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
     </Reference>

--- a/src/Shimmer.Client/UpdateInfo.cs
+++ b/src/Shimmer.Client/UpdateInfo.cs
@@ -29,7 +29,9 @@ namespace Shimmer.Client
             // NB: When bootstrapping, CurrentlyInstalledVersion is null!
             CurrentlyInstalledVersion = currentlyInstalledVersion;
             ReleasesToApply = releasesToApply ?? Enumerable.Empty<ReleaseEntry>();
-            FutureReleaseEntry = ReleasesToApply.MaxBy(x => x.Version).FirstOrDefault();
+            FutureReleaseEntry = ReleasesToApply.Any()
+                    ? ReleasesToApply.MaxBy(x => x.Version).FirstOrDefault()
+                    : null;
             AppFrameworkVersion = appFrameworkVersion;
 
             this.packageDirectory = packageDirectory;
@@ -54,6 +56,10 @@ namespace Shimmer.Client
 
             if (currentVersion == null) {
                 return new UpdateInfo(currentVersion, new[] { latestFull }, packageDirectory, appFrameworkVersion);
+            }
+
+            if (currentVersion.Version == latestFull.Version) {
+                return new UpdateInfo(currentVersion, Enumerable.Empty<ReleaseEntry>(), packageDirectory, appFrameworkVersion);
             }
 
             var newerThanUs = availableReleases.Where(x => x.Version > currentVersion.Version);

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -442,6 +442,9 @@ namespace Shimmer.Client
 
         List<string> runPostInstallOnDirectory(string newAppDirectoryRoot, bool isFirstInstall, Version newCurrentVersion, IEnumerable<ShortcutCreationRequest> shortcutRequestsToIgnore)
         {
+            shortcutRequestsToIgnore.ForEach(x =>
+                log.Info("Ignoring shortcut: {0}", x.TargetPath));
+
             var postInstallInfo = new PostInstallInfo {
                 NewAppDirectoryRoot = newAppDirectoryRoot,
                 IsFirstInstall = isFirstInstall,

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -317,7 +317,7 @@ namespace Shimmer.Client
                 return Observable.Return(UpdateInfo.Create(findCurrentVersion(localReleases), new[] {latestFullRelease}, PackageDirectory, appFrameworkVersion));
             }
 
-            if (localReleases.Max(x => x.Version) >= remoteReleases.Max(x => x.Version)) {
+            if (localReleases.Max(x => x.Version) > remoteReleases.Max(x => x.Version)) {
                 log.Warn("hwhat, local version is greater than remote version");
 
                 var latestFullRelease = findCurrentVersion(remoteReleases);

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -101,10 +101,10 @@ namespace Shimmer.Client
             // HTTP URL
             try {
                 if (isHttpUrl(updateUrlOrPath)) {
-                    this.Log().Info("Downloading RELEASES file from {0}", updateUrlOrPath);
+                    log.Info("Downloading RELEASES file from {0}", updateUrlOrPath);
                     releaseFile = urlDownloader.DownloadUrl(String.Format("{0}/{1}", updateUrlOrPath, "RELEASES"), progress);
                 } else {
-                    this.Log().Info("Reading RELEASES file from {0}", updateUrlOrPath);
+                    log.Info("Reading RELEASES file from {0}", updateUrlOrPath);
                     var fi = fileSystem.GetFileInfo(Path.Combine(updateUrlOrPath, "RELEASES"));
 
                     using (var sr = new StreamReader(fi.OpenRead(), Encoding.UTF8)) {
@@ -508,7 +508,7 @@ namespace Shimmer.Client
         {
             var directory = fileSystem.GetDirectoryInfo(rootAppDirectory);
             if (!directory.Exists) {
-                this.Log().Warn("The directory '{0}' does not exist", rootAppDirectory);
+                log.Warn("The directory '{0}' does not exist", rootAppDirectory);
                 return Enumerable.Empty<ShortcutCreationRequest>();
             }
             

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -51,7 +51,8 @@ namespace Shimmer.Client
             Contract.Requires(!String.IsNullOrEmpty(urlOrPath));
             Contract.Requires(!String.IsNullOrEmpty(applicationName));
 
-            log = LogManager.GetLogger<UpdateManager>();
+            // XXX: ALWAYS BE LOGGING
+            log = new WrappingFullLogger(new FileLogger(applicationName), typeof(UpdateManager));
 
             updateUrlOrPath = urlOrPath;
             this.applicationName = applicationName;
@@ -448,7 +449,7 @@ namespace Shimmer.Client
                 ShortcutRequestsToIgnore = shortcutRequestsToIgnore.ToArray()
             };
 
-            var installerHooks = new InstallerHookOperations(log, fileSystem, applicationName);
+            var installerHooks = new InstallerHookOperations(fileSystem, applicationName);
             return AppDomainHelper.ExecuteInNewAppDomain(postInstallInfo, installerHooks.RunAppSetupInstallers).ToList();
         }
 
@@ -516,7 +517,7 @@ namespace Shimmer.Client
                 .OrderBy(x => x.Name)
                 .SelectMany(oldAppRoot => {
                     var path = oldAppRoot.FullName;
-                    var installerHooks = new InstallerHookOperations(log, fileSystem, applicationName);
+                    var installerHooks = new InstallerHookOperations(fileSystem, applicationName);
 
                     var ret = AppDomainHelper.ExecuteInNewAppDomain(path, installerHooks.RunAppSetupCleanups);
 

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -524,7 +524,9 @@ namespace Shimmer.Client
                     try {
                         Utility.DeleteDirectoryAtNextReboot(oldAppRoot.FullName);
                     } catch (Exception ex) {
-                        log.WarnException("Couldn't delete old app directory on next reboot", ex);
+                        var message = String.Format("Couldn't delete old app directory on next reboot {0}",
+                            oldAppRoot.FullName);
+                        log.WarnException(message, ex);
                     }
                     return ret;
                 });

--- a/src/Shimmer.Core/Shimmer.Core.nuspec
+++ b/src/Shimmer.Core/Shimmer.Core.nuspec
@@ -14,4 +14,8 @@
     <copyright>Copyright 2012 GitHub</copyright>
     <tags>Installer Desktop WiX</tags>
   </metadata>
+
+  <files>
+    <file src="..\..\bin\Ionic.Zip.dll" target="lib\net40\" />
+  </files>
 </package>

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -65,8 +65,7 @@ namespace Shimmer.Core
             Contract.Requires(!String.IsNullOrEmpty(to));
 
             if (!File.Exists(from)) {
-                LogManager.GetLogger(typeof(Utility))
-                          .Warn("The file {0} does not exist", from);
+                Log().Warn("The file {0} does not exist", from);
 
                 // TODO: should we fail this operation?
                 return Observable.Return(Unit.Default);
@@ -136,8 +135,7 @@ namespace Shimmer.Core
             Contract.Requires(!String.IsNullOrEmpty(directoryPath) && Directory.Exists(directoryPath));
 
             if (!Directory.Exists(directoryPath)) {
-                LogManager.GetLogger(typeof(Utility))
-                    .Warn("DeleteDirectoryAtNextReboot: does not exist - {0}", directoryPath);
+                Log().Warn("DeleteDirectoryAtNextReboot: does not exist - {0}", directoryPath);
                 return;
             }
 
@@ -160,8 +158,7 @@ namespace Shimmer.Core
                 Directory.Delete(directoryPath, false);
             } catch (Exception ex) {
                 var message = String.Format("DeleteDirectory: could not delete - {0}", directoryPath);
-                LogManager.GetLogger(typeof(Utility))
-                    .ErrorException(message, ex);
+                Log().ErrorException(message, ex);
                 throw;
             }
         }
@@ -189,8 +186,7 @@ namespace Shimmer.Core
             var di = new DirectoryInfo(directoryPath);
 
             if (!di.Exists) {
-                LogManager.GetLogger(typeof(Utility))
-                    .Warn("DeleteDirectoryAtNextReboot: does not exist - {0}", directoryPath);
+                Log().Warn("DeleteDirectoryAtNextReboot: does not exist - {0}", directoryPath);
                 return;
             }
 
@@ -205,10 +201,14 @@ namespace Shimmer.Core
         {
             if (MoveFileEx(name, null, MoveFileFlags.MOVEFILE_DELAY_UNTIL_REBOOT)) return;
 
-            LogManager.GetLogger(typeof(Utility))
-                .Error("safeDeleteFileAtNextDir: failed - {0}", name);
+            Log().Error("safeDeleteFileAtNextDir: failed - {0}", name);
 
             throw new Win32Exception();
+        }
+
+        static IRxUIFullLogger Log()
+        {
+            return LogManager.GetLogger(typeof(Utility));
         }
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -140,16 +140,29 @@ namespace Shimmer.Core
             }
 
             // From http://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true/329502#329502
-            string[] files = Directory.GetFiles(directoryPath);
-            string[] dirs = Directory.GetDirectories(directoryPath);
+            var files = new string[0];
+            try {
+                files = Directory.GetFiles(directoryPath);
+            } catch (UnauthorizedAccessException ex) {
+                var message = String.Format("The files inside {0} could not be read", directoryPath);
+                Log().Warn(message, ex);
+            }
 
-            foreach (string file in files) {
+            var dirs = new string[0];
+            try {
+                dirs = Directory.GetDirectories(directoryPath);
+            } catch (UnauthorizedAccessException ex) {
+                var message = String.Format("The directories inside {0} could not be read", directoryPath);
+                Log().Warn(message, ex);
+            }
+
+            foreach (var file in files) {
                 File.SetAttributes(file, FileAttributes.Normal);
-                string filePath = file;
+                var filePath = file;
                 (new Action(() => File.Delete(Path.Combine(directoryPath, filePath)))).Retry();
             }
 
-            foreach (string dir in dirs) {
+            foreach (var dir in dirs) {
                 DeleteDirectory(Path.Combine(directoryPath, dir));
             }
 

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -191,17 +191,17 @@ namespace Shimmer.Core
             }
 
             // NB: MoveFileEx blows up if you're a non-admin, so you always need a backup plan
-            di.GetFiles().ForEach(x => safeDeleteFileAtNextDir(x.FullName));
+            di.GetFiles().ForEach(x => safeDeleteFileAtNextReboot(x.FullName));
             di.GetDirectories().ForEach(x => DeleteDirectoryAtNextReboot(x.FullName));
 
-            safeDeleteFileAtNextDir(directoryPath);
+            safeDeleteFileAtNextReboot(directoryPath);
         }
 
-        static void safeDeleteFileAtNextDir(string name)
+        static void safeDeleteFileAtNextReboot(string name)
         {
             if (MoveFileEx(name, null, MoveFileFlags.MOVEFILE_DELAY_UNTIL_REBOOT)) return;
 
-            Log().Error("safeDeleteFileAtNextDir: failed - {0}", name);
+            Log().Error("safeDeleteFileAtNextReboot: failed - {0}", name);
 
             throw new Win32Exception();
         }

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -156,7 +156,14 @@ namespace Shimmer.Core
             }
 
             File.SetAttributes(directoryPath, FileAttributes.Normal);
-            Directory.Delete(directoryPath, false);
+            try {
+                Directory.Delete(directoryPath, false);
+            } catch (Exception ex) {
+                var message = String.Format("DeleteDirectory: could not delete - {0}", directoryPath);
+                LogManager.GetLogger(typeof(Utility))
+                    .ErrorException(message, ex);
+                throw;
+            }
         }
 
         public static Tuple<string, Stream> CreateTempFile()

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -203,7 +203,12 @@ namespace Shimmer.Core
 
         static void safeDeleteFileAtNextDir(string name)
         {
-            if (!MoveFileEx(name, null, MoveFileFlags.MOVEFILE_DELAY_UNTIL_REBOOT)) throw new Win32Exception();
+            if (MoveFileEx(name, null, MoveFileFlags.MOVEFILE_DELAY_UNTIL_REBOOT)) return;
+
+            LogManager.GetLogger(typeof(Utility))
+                .Error("safeDeleteFileAtNextDir: failed - {0}", name);
+
+            throw new Win32Exception();
         }
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]

--- a/src/Shimmer.Tests/Client/ApplyReleasesTests.cs
+++ b/src/Shimmer.Tests/Client/ApplyReleasesTests.cs
@@ -44,6 +44,29 @@ namespace Shimmer.Tests.Client
         }
 
         [Fact]
+        public void WhenNoNewReleasesAreAvailableTheListIsEmpty()
+        {
+            string tempDir;
+            using (Utility.WithTempDirectory(out tempDir)) {
+                Directory.CreateDirectory(Path.Combine(tempDir, "theApp"));
+                var packages = Path.Combine(tempDir, "theApp", "packages");
+                Directory.CreateDirectory(packages);
+
+                new[] {
+                    "Shimmer.Core.1.0.0.0-full.nupkg"
+                }.ForEach(x => File.Copy(IntegrationTestHelper.GetPath("fixtures", x),
+                                         Path.Combine(packages, x)));
+
+                var aGivenPackage = Path.Combine(packages, "Shimmer.Core.1.0.0.0-full.nupkg");
+                var baseEntry = ReleaseEntry.GenerateFromFile(aGivenPackage);
+
+                var updateInfo = UpdateInfo.Create(baseEntry, new[] { baseEntry }, "dontcare", FrameworkVersion.Net40);
+
+                Assert.Empty(updateInfo.ReleasesToApply);
+            }
+        }
+
+        [Fact]
         public void ApplyReleasesWithOneReleaseFile()
         {
             string tempDir;

--- a/src/Shimmer.Tests/Client/ApplyReleasesTests.cs
+++ b/src/Shimmer.Tests/Client/ApplyReleasesTests.cs
@@ -66,6 +66,33 @@ namespace Shimmer.Tests.Client
         }
 
         [Fact]
+        public void ThrowsWhenOnlyDeltaReleasesAreAvailable()
+        {
+            string tempDir;
+            using (Utility.WithTempDirectory(out tempDir))
+            {
+                Directory.CreateDirectory(Path.Combine(tempDir, "theApp"));
+                var packages = Path.Combine(tempDir, "theApp", "packages");
+                Directory.CreateDirectory(packages);
+
+                var baseFile = "Shimmer.Core.1.0.0.0-full.nupkg";
+                File.Copy(IntegrationTestHelper.GetPath("fixtures", baseFile),
+                          Path.Combine(packages, baseFile));
+                var basePackage = Path.Combine(packages, baseFile);
+                var baseEntry = ReleaseEntry.GenerateFromFile(basePackage);
+
+                var deltaFile = "Shimmer.Core.1.1.0.0-delta.nupkg";
+                File.Copy(IntegrationTestHelper.GetPath("fixtures", deltaFile),
+                          Path.Combine(packages, deltaFile));
+                var deltaPackage = Path.Combine(packages, deltaFile);
+                var deltaEntry = ReleaseEntry.GenerateFromFile(deltaPackage);
+
+                Assert.Throws<Exception>(
+                    () => UpdateInfo.Create(baseEntry, new[] { deltaEntry }, "dontcare", FrameworkVersion.Net40));
+            }
+        }
+
+        [Fact]
         public void ApplyReleasesWithOneReleaseFile()
         {
             string tempDir;

--- a/src/Shimmer.Tests/Client/ApplyReleasesTests.cs
+++ b/src/Shimmer.Tests/Client/ApplyReleasesTests.cs
@@ -52,12 +52,11 @@ namespace Shimmer.Tests.Client
                 var packages = Path.Combine(tempDir, "theApp", "packages");
                 Directory.CreateDirectory(packages);
 
-                new[] {
-                    "Shimmer.Core.1.0.0.0-full.nupkg"
-                }.ForEach(x => File.Copy(IntegrationTestHelper.GetPath("fixtures", x),
-                                         Path.Combine(packages, x)));
+                var package = "Shimmer.Core.1.0.0.0-full.nupkg";
+                File.Copy(IntegrationTestHelper.GetPath("fixtures", package),
+                          Path.Combine(packages, package));
 
-                var aGivenPackage = Path.Combine(packages, "Shimmer.Core.1.0.0.0-full.nupkg");
+                var aGivenPackage = Path.Combine(packages, package);
                 var baseEntry = ReleaseEntry.GenerateFromFile(aGivenPackage);
 
                 var updateInfo = UpdateInfo.Create(baseEntry, new[] { baseEntry }, "dontcare", FrameworkVersion.Net40);

--- a/src/Shimmer.Tests/Client/UpdateManagerTests.cs
+++ b/src/Shimmer.Tests/Client/UpdateManagerTests.cs
@@ -170,20 +170,16 @@ namespace Shimmer.Tests.Client
                         fixture.UpdateLocalReleasesFile().Last();
                         ReleaseEntry.BuildReleasesFile(remotePackages);
 
-                        // check for an update
                         updateInfo = fixture.CheckForUpdate().Wait();
-                    }
 
-                    Assert.True(updateInfo.ReleasesToApply.First().IsDelta);
+                        Assert.True(updateInfo.ReleasesToApply.First().IsDelta);
 
-                    using (fixture)
-                    {
-                        // check for an update
                         updateInfo = fixture.CheckForUpdate(ignoreDeltaUpdates:true).Wait();
-                    }
 
-                    Assert.False(updateInfo.ReleasesToApply.First().IsDelta);
+                        Assert.False(updateInfo.ReleasesToApply.First().IsDelta);
+                    }
                 }
+
             }
         }
     }

--- a/src/Shimmer.Tests/Client/UpdateManagerTests.cs
+++ b/src/Shimmer.Tests/Client/UpdateManagerTests.cs
@@ -82,7 +82,7 @@ namespace Shimmer.Tests.Client
                 }
             }
 
-            [Fact(Skip="This test is touching a fair bit of internals")]
+            [Fact]
             public void WhenRemoteReleasesDoNotHaveDeltasNoUpdatesAreApplied()
             {
                 string tempDir;

--- a/src/Shimmer.Tests/Client/UpdateManagerTests.cs
+++ b/src/Shimmer.Tests/Client/UpdateManagerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text;


### PR DESCRIPTION
Testing various scenario inside my demo app:

Done:
- when the current version is the same as the latest version, no updates should be found
- `.MaxBy` assumes it has at least one element - handle that
- "local version is greater than remote version" now is only handled for greater than (not greater than or equal to)
- Ionic.Zip has to ship with Shimmer.Core for applying updates to work
- Shimmer.Client doesn't need to reference Ionic.Zip
- some more logging around when directories are deleted unsuccessfully

Test Plan:
- [x] multiple updates without a restart should work
- [x] after one or more updates only one entry should exist in **Programs and Features**
- [x] uninstalling an updated app should remove the latest version (or mark them all for deletion)  

Open Questions:
-  ~~I have a demo app [here](https://github.com/shiftkey/TestApp) - should it be included under this repository or just renamed to something clearer (Shimmer.Demo for example)?~~ I'll rename it to something more descriptive and push it to it's own repo.
