### PR TITLE
Search the local package folder only once

### DIFF
--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -29,6 +29,15 @@ namespace Shimmer.Core
                 .Concat(rootPath.GetFiles());
         }
 
+        public static IEnumerable<string> GetAllFilePathsRecursively(string rootPath)
+        {
+            Contract.Requires(rootPath != null);
+
+            return Directory.GetDirectories(rootPath)
+                .SelectMany(GetAllFilePathsRecursively)
+                .Concat(Directory.GetFiles(rootPath));
+        }
+
         public static DirectoryInfo CreateRecursive(this DirectoryInfo This)
         {
             This.FullName.Split(Path.DirectorySeparatorChar).scan("", (acc, x) =>

--- a/src/Shimmer.Tests/Core/ReleasePackageTests.cs
+++ b/src/Shimmer.Tests/Core/ReleasePackageTests.cs
@@ -75,7 +75,7 @@ namespace Shimmer.Tests.Core
             var sourceDir = IntegrationTestHelper.GetPath("..", "packages");
             (new DirectoryInfo(sourceDir)).Exists.ShouldBeTrue();
 
-            IEnumerable<IPackage> results = fixture.findAllDependentPackages(null, sourceDir);
+            IEnumerable<IPackage> results = fixture.findAllDependentPackages(null, sourceDir, null);
             results.Count().ShouldBeGreaterThan(0);
         }
 


### PR DESCRIPTION
Previously, even with an SSD, a `New-Release` would take about 20 seconds for my project.

I changed the code, so that the local package folder is only searched once, and packages which dependencies are already looked up aren't looked up twice.

This makes the time for a `New-Release`go down to ~8 seconds for me.

EDIT: I've also created a method `GetAllFilePathsRecursively` that returns file paths, most of the time there is no need to return a `FileInfo` object.
