### PR TITLE
Respect thy mother and father and nuget.config

### DIFF
--- a/src/CreateReleasePackage/tools/Create-Release.ps1
+++ b/src/CreateReleasePackage/tools/Create-Release.ps1
@@ -63,7 +63,10 @@ function Create-ReleaseForProject {
         $pkgFullName = $pkg.FullName
         echo "Found package $pkgFullName"
 
-		$packageDir = Join-Path $solutionDir "packages"
+        $packageDir = Get-NugetPackagesPath($solutionDir)
+        if(-not $packageDir) {
+            $packageDir = Join-Path $solutionDir "packages"
+        }
 		$fullRelease = & $createReleasePackageExe -o $releaseDir -p $packageDir $pkgFullName
 
         ## NB: For absolutely zero reason whatsoever, $fullRelease ends up being the full path Three times
@@ -86,6 +89,31 @@ function Create-ReleaseForProject {
         echo "Running light.exe"		
         & $lightExe -out "$releaseDir\Setup.exe" -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$buildDirectory\template.wixobj"
 	}
+}
+
+function Get-NugetPackagesPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$solutionDir
+    )
+
+    $cfg = Get-ChildItem -Path $solutionDir -Filter nuget.config | Select-Object -first 1
+    if($cfg) {
+        [xml]$config = Get-Content $cfg.FullName
+        $path = $config.configuration.config.add | ?{ $_.key -eq "repositorypath" } | select value
+		# Found nuget.config but it don't has repositorypath attribute
+        if($path) {
+			return $path.value
+		}
+    }
+
+    $parent = Split-Path $solutionDir
+
+    if(-not $parent) {
+        return ""
+    }
+
+    return Get-NugetPackagesPath($parent)
 }
 
 if (-not $ProjectNameToBuild) {

--- a/src/CreateReleasePackage/tools/Create-Release.ps1
+++ b/src/CreateReleasePackage/tools/Create-Release.ps1
@@ -63,7 +63,7 @@ function Create-ReleaseForProject {
         $pkgFullName = $pkg.FullName
         echo "Found package $pkgFullName"
 
-        $packageDir = Get-NugetPackagesPath($solutionDir)
+        $packageDir = Get-NuGetPackagesPath($solutionDir)
         if(-not $packageDir) {
             $packageDir = Join-Path $solutionDir "packages"
         }
@@ -91,29 +91,29 @@ function Create-ReleaseForProject {
 	}
 }
 
-function Get-NugetPackagesPath {
+function Get-NuGetPackagesPath {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$solutionDir
+        [string]$directory
     )
 
-    $cfg = Get-ChildItem -Path $solutionDir -Filter nuget.config | Select-Object -first 1
+    $cfg = Get-ChildItem -Path $directory -Filter nuget.config | Select-Object -first 1
     if($cfg) {
         [xml]$config = Get-Content $cfg.FullName
         $path = $config.configuration.config.add | ?{ $_.key -eq "repositorypath" } | select value
-		# Found nuget.config but it don't has repositorypath attribute
+        # Found nuget.config but it don't has repositorypath attribute
         if($path) {
-			return $path.value
-		}
+            return $path.value.Replace("$", $directory)
+        }
     }
 
     $parent = Split-Path $solutionDir
 
     if(-not $parent) {
-        return ""
+        return $null
     }
 
-    return Get-NugetPackagesPath($parent)
+    return Get-NuGetPackagesPath($parent)
 }
 
 if (-not $ProjectNameToBuild) {

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -56,10 +56,16 @@ function Create-ReleaseForProject {
 
     $releasePackages = @()
 
+    $packageDir = Get-NuGetPackagesPath($solutionDir)
+    if(-not $packageDir) {
+        $packageDir = Join-Path $solutionDir "packages"
+    }
+
+    Write-Host ""
+    Write-Message "Using packages directory $packageDir"
+
     foreach($pkg in $nugetPackages) {
         $pkgFullName = $pkg.FullName
-       
-        $packageDir = Join-Path $solutionDir "packages"
         $releaseOutput = & $createReleasePackageExe -o $releaseDir -p $packageDir $pkgFullName
 
         $packages = $releaseOutput.Split(";")

--- a/src/CreateReleasePackage/tools/utilities.psm1
+++ b/src/CreateReleasePackage/tools/utilities.psm1
@@ -200,3 +200,29 @@ function Add-InstallerTemplate {
         Set-Content -Path $Destination -Value $content	| Out-Null
     }
 }
+
+function Get-NuGetPackagesPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$directory
+    )
+
+    $cfg = Get-ChildItem -Path $directory -Filter nuget.config | Select-Object -first 1
+    if($cfg) {
+        [xml]$config = Get-Content $cfg.FullName
+        $path = $config.configuration.config.add | ?{ $_.key -eq "repositorypath" } | select value
+        # Found nuget.config but it don't has repositorypath attribute
+        if($path) {
+            return $path.value.Replace("$", $directory)
+        }
+    }
+
+    $parent = Split-Path $solutionDir
+
+    if(-not $parent) {
+        return $null
+    }
+
+    return Get-NuGetPackagesPath($parent)
+}
+


### PR DESCRIPTION
Builds upon #92 and covers some additional gaps:
- the `New-Release` script needs to call the `Get-NuGetPackagesPath` method
- the $ token (if found) needs to be overwritten
- renamed `$solutionDir` to `$directory` to indicate the method is more generic
