### PR TITLE
Use helper methods

### DIFF
--- a/src/Shimmer.Client/IAppSetup.cs
+++ b/src/Shimmer.Client/IAppSetup.cs
@@ -44,7 +44,7 @@ namespace Shimmer.Client
             }
 
             if (createDirectoryIfNecessary && Directory.Exists(dir)) {
-                (new DirectoryInfo(dir)).CreateRecursive();
+                Directory.CreateDirectory(dir);
             }
 
             return Path.Combine(dir, Title + ".lnk");

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -406,9 +406,9 @@ namespace Shimmer.Client
             // NB: We sort this list in order to guarantee that if a Net20
             // and a Net40 version of a DLL get shipped, we always end up
             // with the 4.0 version.
-            pkg.GetFiles().Where(x => pathIsInFrameworkProfile(x, appFrameworkVersion))
-                          .OrderBy(x => x.Path)
-                          .ForEach(x => CopyFileToLocation(target, x));
+            pkg.GetLibFiles().Where(x => pathIsInFrameworkProfile(x, appFrameworkVersion))
+                             .OrderBy(x => x.Path)
+                             .ForEach(x => CopyFileToLocation(target, x));
 
             pkg.GetContentFiles().ForEach(x => CopyFileToLocation(target, x));
 

--- a/src/Shimmer.Core/IFileSystemFactory.cs
+++ b/src/Shimmer.Core/IFileSystemFactory.cs
@@ -92,7 +92,7 @@ namespace Shimmer.Core
                     s => new DirectoryInfoWrapper(new System.IO.DirectoryInfo(s)),
                     s => new FileInfoWrapper(new System.IO.FileInfo(s)),
                     s => new FileWrapper(),
-                    s => new DirectoryInfoWrapper(new System.IO.DirectoryInfo(s).CreateRecursive()),
+                    s => new DirectoryInfoWrapper(System.IO.Directory.CreateDirectory(s)),
                     s => new System.IO.DirectoryInfo(s).Delete(true),
                     Utility.CopyToAsync,
                     Utility.CreateTempFile);

--- a/src/Shimmer.Core/ReleasePackage.cs
+++ b/src/Shimmer.Core/ReleasePackage.cs
@@ -129,7 +129,7 @@ namespace Shimmer.Core
             dependencies.ForEach(pkg => {
                 this.Log().Info("Scanning {0}", pkg.Id);
 
-                pkg.GetFiles().Where(x => x.Path.StartsWith("lib", true, CultureInfo.InvariantCulture)).ForEach(file => {
+                pkg.GetLibFiles().ForEach(file => {
                     var outPath = new FileInfo(Path.Combine(tempPath.FullName, file.Path));
 
                     if(isNonDesktopAssembly(file.Path)) {
@@ -238,7 +238,7 @@ namespace Shimmer.Core
 
             if (packagesRootDir != null && localPackageCache == null) {
                 localPackageCache = Utility.GetAllFilePathsRecursively(packagesRootDir)
-                    .Where(x => x.EndsWith("nupkg", StringComparison.InvariantCultureIgnoreCase))
+                    .Where(PackageHelper.IsPackageFile)
                     .Select(x => new ZipPackage(x))
                     .ToArray();
             }

--- a/src/Shimmer.Core/ReleasePackage.cs
+++ b/src/Shimmer.Core/ReleasePackage.cs
@@ -137,7 +137,7 @@ namespace Shimmer.Core
                         return;
                     }
 
-                    outPath.Directory.CreateRecursive();
+                    Directory.CreateDirectory(outPath.Directory.FullName);
 
                     using (var of = File.Create(outPath.FullName)) {
                         this.Log().Info("Writing {0} to {1}", file.Path, outPath);

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -38,28 +38,6 @@ namespace Shimmer.Core
                 .Concat(Directory.GetFiles(rootPath));
         }
 
-        public static DirectoryInfo CreateRecursive(this DirectoryInfo This)
-        {
-            This.FullName.Split(Path.DirectorySeparatorChar).scan("", (acc, x) =>
-            {
-                var path = Path.Combine(acc, x);
-
-                if (path[path.Length - 1] == Path.VolumeSeparatorChar)
-                {
-                    path += Path.DirectorySeparatorChar;
-                }
-
-                if (!Directory.Exists(path))
-                {
-                    Directory.CreateDirectory(path);
-                }
-
-                return (new DirectoryInfo(path)).FullName;
-            });
-
-            return This;
-        }
-
         public static string CalculateStreamSHA1(Stream file)
         {
             Contract.Requires(file != null && file.CanRead);

--- a/src/Shimmer.Tests/Client/ApplyReleasesTests.cs
+++ b/src/Shimmer.Tests/Client/ApplyReleasesTests.cs
@@ -332,16 +332,16 @@ namespace Shimmer.Tests.Client
             string tempDir;
             using (acquireEnvVarLock())
             using (Utility.WithTempDirectory(out tempDir)) {
-                var di = new DirectoryInfo(Path.Combine(tempDir, "theApp", "app-1.1.0.0"));
-                di.CreateRecursive();
+                var di = Path.Combine(tempDir, "theApp", "app-1.1.0.0");
+                Directory.CreateDirectory(di);
 
-                File.Copy(getPathToShimmerTestTarget(), Path.Combine(di.FullName, "ShimmerIAppUpdateTestTarget.exe"));
+                File.Copy(getPathToShimmerTestTarget(), Path.Combine(di, "ShimmerIAppUpdateTestTarget.exe"));
 
                 var fixture = new UpdateManager("http://lol", "theApp", FrameworkVersion.Net40, tempDir, null, null);
 
                 this.Log().Info("Invoking post-install");
                 var mi = fixture.GetType().GetMethod("runPostInstallOnDirectory", BindingFlags.NonPublic | BindingFlags.Instance);
-                mi.Invoke(fixture, new object[] { di.FullName, true, new Version(1, 1, 0, 0), Enumerable.Empty<ShortcutCreationRequest>() });
+                mi.Invoke(fixture, new object[] { di, true, new Version(1, 1, 0, 0), Enumerable.Empty<ShortcutCreationRequest>() });
 
                 getEnvVar("AppInstall_Called").ShouldEqual("1");
                 getEnvVar("VersionInstalled_Called").ShouldEqual("1.1.0.0");
@@ -355,16 +355,16 @@ namespace Shimmer.Tests.Client
             using (acquireEnvVarLock())
             using (Utility.WithTempDirectory(out tempDir)) 
             using (setEnvVar("ShortcutDir", tempDir)) {
-                var di = new DirectoryInfo(Path.Combine(tempDir, "theApp", "app-1.1.0.0"));
-                di.CreateRecursive();
+                var di = Path.Combine(tempDir, "theApp", "app-1.1.0.0");
+                Directory.CreateDirectory(di);
 
-                File.Copy(getPathToShimmerTestTarget(), Path.Combine(di.FullName, "ShimmerIAppUpdateTestTarget.exe"));
+                File.Copy(getPathToShimmerTestTarget(), Path.Combine(di, "ShimmerIAppUpdateTestTarget.exe"));
 
                 var fixture = new UpdateManager("http://lol", "theApp", FrameworkVersion.Net40, tempDir, null, null);
 
                 this.Log().Info("Invoking post-install");
                 var mi = fixture.GetType().GetMethod("runPostInstallOnDirectory", BindingFlags.NonPublic | BindingFlags.Instance);
-                mi.Invoke(fixture, new object[] { di.FullName, true, new Version(1, 1, 0, 0), Enumerable.Empty<ShortcutCreationRequest>() });
+                mi.Invoke(fixture, new object[] { di, true, new Version(1, 1, 0, 0), Enumerable.Empty<ShortcutCreationRequest>() });
 
                 File.Exists(Path.Combine(tempDir, "Foo.lnk")).ShouldBeTrue();
             }
@@ -384,10 +384,10 @@ namespace Shimmer.Tests.Client
             using (acquireEnvVarLock())
             using (setShouldThrow())
             using (Utility.WithTempDirectory(out tempDir)) {
-                var di = new DirectoryInfo(Path.Combine(tempDir, "theApp", "app-1.1.0.0"));
-                di.CreateRecursive();
+                var di = Path.Combine(tempDir, "theApp", "app-1.1.0.0");
+                Directory.CreateDirectory(di);
 
-                File.Copy(getPathToShimmerTestTarget(), Path.Combine(di.FullName, "ShimmerIAppUpdateTestTarget.exe"));
+                File.Copy(getPathToShimmerTestTarget(), Path.Combine(di, "ShimmerIAppUpdateTestTarget.exe"));
 
                 var fixture = new UpdateManager("http://lol", "theApp", FrameworkVersion.Net40, tempDir, null, null);
 
@@ -396,7 +396,7 @@ namespace Shimmer.Tests.Client
                     this.Log().Info("Invoking post-install");
 
                     var mi = fixture.GetType().GetMethod("runPostInstallOnDirectory", BindingFlags.NonPublic | BindingFlags.Instance);
-                    mi.Invoke(fixture, new object[] { di.FullName, true, new Version(1, 1, 0, 0), Enumerable.Empty<ShortcutCreationRequest>() });
+                    mi.Invoke(fixture, new object[] { di, true, new Version(1, 1, 0, 0), Enumerable.Empty<ShortcutCreationRequest>() });
                 } catch (TargetInvocationException ex) {
                     this.Log().Info("Expected to receive Exception", ex);
 

--- a/src/Shimmer.Tests/Client/DownloadReleasesTests.cs
+++ b/src/Shimmer.Tests/Client/DownloadReleasesTests.cs
@@ -140,7 +140,7 @@ namespace Shimmer.Tests.Client
             using (Utility.WithTempDirectory(out tempDir)) {
                 // NB: This is normally done by CheckForUpdates, but since 
                 // we're skipping that in the test we have to do it ourselves
-                (new DirectoryInfo(Path.Combine(tempDir, "SampleUpdatingApp", "packages"))).CreateRecursive();
+                Directory.CreateDirectory(Path.Combine(tempDir, "SampleUpdatingApp", "packages"));
 
                 var fixture = new UpdateManager("http://localhost:30405", "SampleUpdatingApp", FrameworkVersion.Net40, tempDir);
                 using (fixture) {
@@ -181,7 +181,7 @@ namespace Shimmer.Tests.Client
             using (Utility.WithTempDirectory(out tempDir)) {
                 // NB: This is normally done by CheckForUpdates, but since 
                 // we're skipping that in the test we have to do it ourselves
-                (new DirectoryInfo(Path.Combine(tempDir, "SampleUpdatingApp", "packages"))).CreateRecursive();
+                Directory.CreateDirectory(Path.Combine(tempDir, "SampleUpdatingApp", "packages"));
 
                 var fixture = new UpdateManager(updateDir.FullName, "SampleUpdatingApp", FrameworkVersion.Net40, tempDir);
                 using (fixture) {


### PR DESCRIPTION
This Pr does the following things:
- Use the `GetLibFiles()` extension method from NuGet.Core to retrieve the lib folder in a package
- Use `PackageHelper.IsPackage` from NuGet.Core to determine if a file is a NuGet package
- `Directory.CreateDirectory` does a recursive creation by default, so the `CreateRecursive` extension method is not needed
