### PR TITLE
Uninstall should be amazing

### DIFF
--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -432,14 +432,14 @@ namespace Shimmer.Client
 
             using (var inf = x.GetStream())
             using (var of = fi.Open(FileMode.CreateNew, FileAccess.Write)) {
-                log.Info("Writing {0} to app directory", targetPath);
+                log.Debug("Writing {0} to app directory", targetPath);
                 inf.CopyTo(of);
             }
         }
 
         List<string> runPostInstallAndCleanup(Version newCurrentVersion, bool isBootstrapping)
         {
-            log.Debug(CultureInfo.InvariantCulture, "AppDomain ID: {0}", AppDomain.CurrentDomain.Id);
+            log.Debug("AppDomain ID: {0}", AppDomain.CurrentDomain.Id);
 
             fixPinnedExecutables(newCurrentVersion);
 

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -614,8 +614,7 @@ namespace Shimmer.Client
             return di.GetDirectories().ToObservable()
                 .Where(x => x.Name.ToLowerInvariant().Contains("app-"))
                 .Where(x => currentVersion != null ? x.Name != getDirectoryForRelease(currentVersion).Name : true)
-                .SelectMany(x => Utility.DeleteDirectory(x.FullName))
-                .ObserveOn(RxApp.TaskpoolScheduler)
+                .SelectMany(x => Utility.DeleteDirectory(x.FullName, RxApp.TaskpoolScheduler))
                     .LoggedCatch<Unit, UpdateManager, UnauthorizedAccessException>(this, _ => Observable.Return(Unit.Default))
                 .Aggregate(Unit.Default, (acc, x) => acc);
         }

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -451,9 +451,6 @@ namespace Shimmer.Client
 
         List<string> runPostInstallOnDirectory(string newAppDirectoryRoot, bool isFirstInstall, Version newCurrentVersion, IEnumerable<ShortcutCreationRequest> shortcutRequestsToIgnore)
         {
-            shortcutRequestsToIgnore.ForEach(x =>
-                log.Info("Ignoring shortcut: {0}", x.TargetPath));
-
             var postInstallInfo = new PostInstallInfo {
                 NewAppDirectoryRoot = newAppDirectoryRoot,
                 IsFirstInstall = isFirstInstall,

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -216,9 +216,8 @@ namespace Shimmer.Client
         {
             var maxVersion = new Version(255, 255, 255, 255);
             return
-                Observable.Start(() => cleanUpOldVersions(maxVersion))
+                Observable.Start(() => cleanUpOldVersions(maxVersion), RxApp.TaskpoolScheduler)
                 .SelectMany(_ => Utility.DeleteDirectory(rootAppDirectory))
-                .ObserveOn(RxApp.TaskpoolScheduler)
                 .Catch<Unit, Exception>(ex => {
                     log.WarnException(
                         "Full Uninstall failed to delete root dir, punting to next reboot", ex);

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -224,8 +224,6 @@ namespace Shimmer.Core
             if (MoveFileEx(name, null, MoveFileFlags.MOVEFILE_DELAY_UNTIL_REBOOT)) return;
 
             Log().Error("safeDeleteFileAtNextReboot: failed - {0}", name);
-
-            throw new Win32Exception();
         }
 
         static IRxUIFullLogger Log()

--- a/src/Shimmer.Tests/Core/UtilityTests.cs
+++ b/src/Shimmer.Tests/Core/UtilityTests.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using Shimmer.Core;
 using Shimmer.Tests.TestHelpers;
 using Xunit;
@@ -11,7 +8,6 @@ namespace Shimmer.Tests.Core
 {
     public class UtilityTests
     {
-
         [Fact]
         public void ShaCheckShouldBeCaseInsensitive()
         {
@@ -22,7 +18,6 @@ namespace Shimmer.Tests.Core
 
             Assert.NotEqual(sha1FromExternalTool, sha1);
             Assert.Equal(sha1FromExternalTool, sha1, StringComparer.OrdinalIgnoreCase);
-
         }
     }
 }

--- a/src/Shimmer.Tests/Core/UtilityTests.cs
+++ b/src/Shimmer.Tests/Core/UtilityTests.cs
@@ -1,12 +1,18 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using ReactiveUI;
 using Shimmer.Core;
 using Shimmer.Tests.TestHelpers;
 using Xunit;
 
 namespace Shimmer.Tests.Core
 {
-    public class UtilityTests
+    public class UtilityTests : IEnableLogger
     {
         [Fact]
         public void ShaCheckShouldBeCaseInsensitive()
@@ -18,6 +24,72 @@ namespace Shimmer.Tests.Core
 
             Assert.NotEqual(sha1FromExternalTool, sha1);
             Assert.Equal(sha1FromExternalTool, sha1, StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void CanDeleteDeepRecursiveDirectoryStructure()
+        {
+            string tempDir;
+            using (Utility.WithTempDirectory(out tempDir)) {
+
+                for (var i = 0; i < 50; i++) {
+                    var directory = Path.Combine(tempDir, newId());
+                    CreateSampleDirectory(directory);
+                }
+
+                var files = Directory.GetFiles(tempDir, "*", SearchOption.AllDirectories);
+
+                var count = files.Count();
+
+                this.Log().Info("Created {0} files under directory {1}", count, tempDir);
+
+                var sw = new Stopwatch();
+                sw.Start();
+                Utility.DeleteDirectory(tempDir).Wait();
+                sw.Stop();
+                this.Log().Info("Delete took {0}ms", sw.ElapsedMilliseconds);
+
+                Assert.False(Directory.Exists(tempDir));
+            }
+        }
+
+        static void CreateSampleDirectory(string directory)
+        {
+            while (true) {
+                Directory.CreateDirectory(directory);
+
+                for (var j = 0; j < 100; j++) {
+                    var file = Path.Combine(directory, newId());
+                    if (file.Length > 260) continue;
+                    File.WriteAllText(file, Guid.NewGuid().ToString());
+                }
+
+                if (new Random().NextDouble() > 0.5) {
+                    var childDirectory = Path.Combine(directory, newId());
+                    if (childDirectory.Length > 248) return;
+                    directory = childDirectory;
+                    continue;
+                }
+                break;
+            }
+        }
+
+        static string newId()
+        {
+            var text = Guid.NewGuid().ToString();
+            var bytes = Encoding.Unicode.GetBytes(text);
+            var provider = new SHA1Managed();
+            var hashString = string.Empty;
+
+            foreach (var x in provider.ComputeHash(bytes)) {
+                hashString += String.Format("{0:x2}", x);
+            }
+
+            if (hashString.Length > 7) {
+                return hashString.Substring(0, 7);
+            }
+
+            return hashString;
         }
     }
 }


### PR DESCRIPTION
Resolving #74 

Fixes:
- a stupid enumeration thing I introduced
- moved some diagnostics out to debug to slim down normal logs

TODO:
- [x] on uninstall, deleting the directory supposedly fails as it's not empty, but upon inspection the folder is empty (race condition?)

```
ERROR | 2013-09-10 01:27:46 PM +09 | Utility: DeleteDirectory: could not delete -
 C:\Users\brendanforster\AppData\Local\TestApp: System.IO.IOException: The directory is not empty.

   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, 
          Boolean throwOnTopLevelDirectoryNotFound)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, 
          Boolean checkHost)
   at System.IO.Directory.Delete(String path, Boolean recursive)
   at Shimmer.Core.Utility.DeleteDirectory(String directoryPath)
WARN | 2013-09-10 01:27:46 PM +09 | UpdateManager: Full Uninstall tried to delete root
 dir but failed, punting until next reboot: System.IO.IOException: The directory is not empty.

   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, 
        Boolean throwOnTopLevelDirectoryNotFound)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, 
        Boolean checkHost)
   at System.IO.Directory.Delete(String path, Boolean recursive)
   at Shimmer.Core.Utility.DeleteDirectory(String directoryPath)
   at Shimmer.Client.UpdateManager.<fullUninstall>b__26()
ERROR | 2013-09-10 01:27:46 PM +09 | Utility: safeDeleteFileAtNextReboot: failed -
  C:\Users\brendanforster\AppData\Local\TestApp
INFO | 2013-09-10 01:27:49 PM +09 | InstallManager: Full uninstall OnNext: ()
INFO | 2013-09-10 01:27:49 PM +09 | InstallManager: Full uninstall OnCompleted
```
