### PR TITLE
Add -ReleasesDirectory to Create-Release and Create-ReleaseForProject

### DIFF
--- a/src/CreateReleasePackage/tools/Create-Release.ps1
+++ b/src/CreateReleasePackage/tools/Create-Release.ps1
@@ -4,6 +4,8 @@ param (
 	[string] $SolutionDir,
 	[Parameter(Mandatory=$true)]
 	[string] $BuildDirectory
+	[Parameter(Mandatory = $false)]
+	[string]$ReleaseDirectory = Join-Path $SolutionDir "Releases"
 )
 
 Set-PSDebug -Strict
@@ -14,4 +16,5 @@ Import-Module (Join-Path $toolsDir "utilities.psm1")
 Import-Module (Join-Path $toolsDir "commands.psm1")
 
 Create-ReleaseForProject -SolutionDir $SolutionDir `
-                         -BuildDirectory $BuildDirectory
+                         -BuildDirectory $BuildDirectory `
+                         -ReleaseDirectory $ReleaseDirectory

--- a/src/CreateReleasePackage/tools/Create-Release.ps1
+++ b/src/CreateReleasePackage/tools/Create-Release.ps1
@@ -3,9 +3,9 @@ param (
 	[Parameter(Mandatory=$true)]
 	[string] $SolutionDir,
 	[Parameter(Mandatory=$true)]
-	[string] $BuildDirectory
+	[string] $BuildDirectory,
 	[Parameter(Mandatory = $false)]
-	[string]$ReleaseDirectory = Join-Path $SolutionDir "Releases"
+	[string]$ReleasesDirectory = (Join-Path $SolutionDir "Releases")
 )
 
 Set-PSDebug -Strict
@@ -17,4 +17,4 @@ Import-Module (Join-Path $toolsDir "commands.psm1")
 
 Create-ReleaseForProject -SolutionDir $SolutionDir `
                          -BuildDirectory $BuildDirectory `
-                         -ReleaseDirectory $ReleaseDirectory
+                         -ReleasesDirectory $ReleasesDirectory

--- a/src/CreateReleasePackage/tools/Create-Release.ps1
+++ b/src/CreateReleasePackage/tools/Create-Release.ps1
@@ -3,9 +3,9 @@ param (
 	[Parameter(Mandatory=$true)]
 	[string] $SolutionDir,
 	[Parameter(Mandatory=$true)]
-	[string] $BuildDirectory,
+	[string] $BuildDir,
 	[Parameter(Mandatory = $false)]
-	[string]$ReleasesDirectory = (Join-Path $SolutionDir "Releases")
+	[string]$ReleasesDir = (Join-Path $SolutionDir "Releases")
 )
 
 Set-PSDebug -Strict
@@ -16,5 +16,5 @@ Import-Module (Join-Path $toolsDir "utilities.psm1")
 Import-Module (Join-Path $toolsDir "commands.psm1")
 
 Create-ReleaseForProject -SolutionDir $SolutionDir `
-                         -BuildDirectory $BuildDirectory `
-                         -ReleasesDirectory $ReleasesDirectory
+                         -BuildDir $BuildDir `
+                         -ReleasesDir $ReleasesDir

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -25,12 +25,13 @@ function Create-ReleaseForProject {
         [Parameter(Mandatory = $true)]
         [string]$solutionDir,
         [Parameter(Mandatory = $true)]
-        [string]$buildDirectory
+        [string]$buildDirectory,
+        [Parameter(Mandatory = $false)]
+        [string]$releasesDirectory = Join-Path $solutionDir "Releases"
     )
 
-    $releaseDir = Join-Path $solutionDir "Releases"
-    if (!(Test-Path $releaseDir)) { `
-        New-Item -ItemType Directory -Path $releaseDir | Out-Null
+    if (!(Test-Path $releasesDirectory)) { `
+        New-Item -ItemType Directory -Path $releasesDirectory | Out-Null
     }
 
     Write-Message "Checking $buildDirectory for packages`n"

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -27,7 +27,7 @@ function Create-ReleaseForProject {
         [Parameter(Mandatory = $true)]
         [string]$buildDirectory,
         [Parameter(Mandatory = $false)]
-        [string]$releasesDirectory = Join-Path $solutionDir "Releases"
+        [string]$releasesDirectory = (Join-Path $solutionDir "Releases")
     )
 
     if (!(Test-Path $releasesDirectory)) { `
@@ -53,7 +53,7 @@ function Create-ReleaseForProject {
     }
 
     Write-Host ""
-    Write-Message "Publishing artifacts to $releaseDir"
+    Write-Message "Publishing artifacts to $releasesDirectory"
 
     $releasePackages = @()
 
@@ -67,7 +67,7 @@ function Create-ReleaseForProject {
 
     foreach($pkg in $nugetPackages) {
         $pkgFullName = $pkg.FullName
-        $releaseOutput = & $createReleasePackageExe -o $releaseDir -p $packageDir $pkgFullName
+        $releaseOutput = & $createReleasePackageExe -o $releasesDirectory -p $packageDir $pkgFullName
 
         $packages = $releaseOutput.Split(";")
         $fullRelease = $packages[0].Trim()
@@ -109,8 +109,8 @@ function Create-ReleaseForProject {
     Remove-ItemSafe "$buildDirectory\template.wixobj"
 
     Write-Message "Running candle.exe"
-    & $candleExe -d"ToolsDir=$toolsDir" -d"ReleasesFile=$releaseDir\RELEASES" -d"NuGetFullPackage=$latestFullRelease" -out "$buildDirectory\template.wixobj" -arch x86 -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$wixTemplate"
+    & $candleExe -d"ToolsDir=$toolsDir" -d"ReleasesFile=$releasesDirectory\RELEASES" -d"NuGetFullPackage=$latestFullRelease" -out "$buildDirectory\template.wixobj" -arch x86 -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$wixTemplate"
 
     Write-Message "Running light.exe"
-    & $lightExe -out "$releaseDir\Setup.exe" -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$buildDirectory\template.wixobj"
+    & $lightExe -out "$releasesDirectory\Setup.exe" -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$buildDirectory\template.wixobj"
 }

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -23,20 +23,20 @@ function Generate-TemplateFromPackage {
 function Create-ReleaseForProject {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$solutionDir,
+        [string]$SolutionDir,
         [Parameter(Mandatory = $true)]
-        [string]$buildDirectory,
+        [string]$BuildDir,
         [Parameter(Mandatory = $false)]
-        [string]$releasesDirectory = (Join-Path $solutionDir "Releases")
+        [string]$ReleasesDir = (Join-Path $SolutionDir "Releases")
     )
 
-    if (!(Test-Path $releasesDirectory)) { `
-        New-Item -ItemType Directory -Path $releasesDirectory | Out-Null
+    if (!(Test-Path $ReleasesDir)) { `
+        New-Item -ItemType Directory -Path $ReleasesDir | Out-Null
     }
 
-    Write-Message "Checking $buildDirectory for packages`n"
+    Write-Message "Checking $BuildDir for packages`n"
 
-    $nugetPackages = ls "$buildDirectory\*.nupkg" `
+    $nugetPackages = ls "$BuildDir\*.nupkg" `
         | ?{ $_.Name.EndsWith(".symbols.nupkg") -eq $false } `
         | sort @{expression={$_.LastWriteTime};Descending=$false}
 
@@ -53,13 +53,13 @@ function Create-ReleaseForProject {
     }
 
     Write-Host ""
-    Write-Message "Publishing artifacts to $releasesDirectory"
+    Write-Message "Publishing artifacts to $ReleasesDir"
 
     $releasePackages = @()
 
-    $packageDir = Get-NuGetPackagesPath($solutionDir)
+    $packageDir = Get-NuGetPackagesPath($SolutionDir)
     if(-not $packageDir) {
-        $packageDir = Join-Path $solutionDir "packages"
+        $packageDir = Join-Path $SolutionDir "packages"
     }
 
     Write-Host ""
@@ -67,7 +67,7 @@ function Create-ReleaseForProject {
 
     foreach($pkg in $nugetPackages) {
         $pkgFullName = $pkg.FullName
-        $releaseOutput = & $createReleasePackageExe -o $releasesDirectory -p $packageDir $pkgFullName
+        $releaseOutput = & $createReleasePackageExe -o $ReleasesDir -p $packageDir $pkgFullName
 
         $packages = $releaseOutput.Split(";")
         $fullRelease = $packages[0].Trim()
@@ -101,16 +101,16 @@ function Create-ReleaseForProject {
     Write-Message "Creating installer for $latestFullRelease"
 
     $candleTemplate = Generate-TemplateFromPackage $latestPackageSource "$toolsDir\template.wxs"
-    $wixTemplate = Join-Path $buildDirectory "template.wxs"
+    $wixTemplate = Join-Path $BuildDir "template.wxs"
 
     Remove-ItemSafe $wixTemplate
     mv $candleTemplate $wixTemplate | Out-Null
 
-    Remove-ItemSafe "$buildDirectory\template.wixobj"
+    Remove-ItemSafe "$BuildDir\template.wixobj"
 
     Write-Message "Running candle.exe"
-    & $candleExe -d"ToolsDir=$toolsDir" -d"ReleasesFile=$releasesDirectory\RELEASES" -d"NuGetFullPackage=$latestFullRelease" -out "$buildDirectory\template.wixobj" -arch x86 -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$wixTemplate"
+    & $candleExe -d"ToolsDir=$toolsDir" -d"ReleasesFile=$ReleasesDir\RELEASES" -d"NuGetFullPackage=$latestFullRelease" -out "$BuildDir\template.wixobj" -arch x86 -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$wixTemplate"
 
     Write-Message "Running light.exe"
-    & $lightExe -out "$releasesDirectory\Setup.exe" -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$buildDirectory\template.wixobj"
+    & $lightExe -out "$ReleasesDir\Setup.exe" -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$BuildDir\template.wixobj"
 }

--- a/src/CreateReleasePackage/tools/visualstudio.psm1
+++ b/src/CreateReleasePackage/tools/visualstudio.psm1
@@ -24,7 +24,7 @@ function New-Release {
     $outputDir =  $project.ConfigurationManager.ActiveConfiguration.Properties.Item("OutputPath").Value
     
     Create-ReleaseForProject -SolutionDir $solutionDir `
-                             -BuildDirectory (Join-Path $projectDir $outputDir)
+                             -BuildDir (Join-Path $projectDir $outputDir)
 }
 
 Register-TabExpansion 'New-Release' @{


### PR DESCRIPTION
My build server script directly uses Create-ReleaseForProject and here is the local change I made to allow it to create releases on our network share.

This commit partially addresses https://github.com/github/Shimmer/issues/106 I don't use the New-Release command so I didn't want to (incorrectly) wire that up.
