### PR TITLE
Of Mice and Passing Arguments to Commands in Powershell v2

### DIFF
--- a/src/CreateReleasePackage/tools/Create-Release.ps1
+++ b/src/CreateReleasePackage/tools/Create-Release.ps1
@@ -15,6 +15,6 @@ $toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Import-Module (Join-Path $toolsDir "utilities.psm1")
 Import-Module (Join-Path $toolsDir "commands.psm1")
 
-Create-ReleaseForProject -SolutionDir $SolutionDir `
+New-ReleaseForPackage -SolutionDir $SolutionDir `
                          -BuildDir $BuildDir `
                          -ReleasesDir $ReleasesDir

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -8,7 +8,7 @@ $wixDir = Join-Path $toolsDir "wix"
 $candleExe = Join-Path $wixDir "candle.exe"
 $lightExe = Join-Path $wixDir "light.exe"
 
-function Generate-TemplateFromPackage {
+function New-TemplateFromPackage {
     param(
         [Parameter(Mandatory = $true)]
         [string]$packageFile,
@@ -20,7 +20,7 @@ function Generate-TemplateFromPackage {
     $resultFile
 }
 
-function Create-ReleaseForProject {
+function New-ReleaseForPackage {
     param(
         [Parameter(Mandatory = $true)]
         [string]$SolutionDir,
@@ -100,7 +100,7 @@ function Create-ReleaseForProject {
     Write-Host ""
     Write-Message "Creating installer for $latestFullRelease"
 
-    $candleTemplate = Generate-TemplateFromPackage $latestPackageSource "$toolsDir\template.wxs"
+    $candleTemplate = New-TemplateFromPackage $latestPackageSource "$toolsDir\template.wxs"
     $wixTemplate = Join-Path $BuildDir "template.wxs"
 
     Remove-ItemSafe $wixTemplate

--- a/src/CreateReleasePackage/tools/commands.psm1
+++ b/src/CreateReleasePackage/tools/commands.psm1
@@ -106,10 +106,20 @@ function Create-ReleaseForProject {
     Remove-ItemSafe $wixTemplate
     mv $candleTemplate $wixTemplate | Out-Null
 
+    # we are all made of stars and string replacement code
+    $releasesFile = Join-Path $ReleasesDir "RELEASES"
+    $templateText = Get-Content $wixTemplate
+    $templateText = $templateText `
+                        -Replace "\$\(var.ToolsDir\)", $toolsDir `
+                        -Replace "\$\(var.ReleasesFile\)", $releasesFile `
+                        -Replace "\$\(var.NuGetFullPackage\)", $latestFullRelease
+    
+    Set-Content $wixTemplate $templateText
+    
     Remove-ItemSafe "$BuildDir\template.wixobj"
 
     Write-Message "Running candle.exe"
-    & $candleExe -d"ToolsDir=$toolsDir" -d"ReleasesFile=$ReleasesDir\RELEASES" -d"NuGetFullPackage=$latestFullRelease" -out "$BuildDir\template.wixobj" -arch x86 -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$wixTemplate"
+    & $candleExe -out "$BuildDir\template.wixobj" -arch x86 -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$wixTemplate"
 
     Write-Message "Running light.exe"
     & $lightExe -out "$ReleasesDir\Setup.exe" -ext "$wixDir\WixBalExtension.dll" -ext "$wixDir\WixUtilExtension.dll" "$BuildDir\template.wixobj"

--- a/src/CreateReleasePackage/tools/utilities.psm1
+++ b/src/CreateReleasePackage/tools/utilities.psm1
@@ -104,16 +104,9 @@ function Get-ProjectItem {
     )
 
     (Resolve-ProjectName $ProjectName) | %{
+        $_.ProjectItems | Where-Object { $_.Name -eq $FileName } `
+                        | Select-Object -first 1
 
-        $existingFile = $_.ProjectItems | Where-Object { $_.Name -eq $FileName }
-
-        if ($existingFile -eq $null) {
-            $null
-        } elseif ($existingFile.length -eq 0) {
-            $null
-        } else {
-            $existingFile[0]
-        }
     }
 }
 

--- a/src/CreateReleasePackage/tools/utilities.psm1
+++ b/src/CreateReleasePackage/tools/utilities.psm1
@@ -107,7 +107,9 @@ function Get-ProjectItem {
 
         $existingFile = $_.ProjectItems | Where-Object { $_.Name -eq $FileName }
 
-        if ($existingFile.length -eq 0) {
+        if ($existingFile -eq $null) {
+            $null
+        } elseif ($existingFile.length -eq 0) {
             $null
         } else {
             $existingFile[0]

--- a/src/CreateReleasePackage/tools/visualstudio.psm1
+++ b/src/CreateReleasePackage/tools/visualstudio.psm1
@@ -23,7 +23,7 @@ function New-Release {
     $projectDir = (gci $project.FullName).Directory
     $outputDir =  $project.ConfigurationManager.ActiveConfiguration.Properties.Item("OutputPath").Value
     
-    Create-ReleaseForProject -SolutionDir $solutionDir `
+    New-ReleaseForPackage -SolutionDir $solutionDir `
                              -BuildDir (Join-Path $projectDir $outputDir)
 }
 


### PR DESCRIPTION
Resolves #134 
Replaces #137 

There's an issue with how passing an argument like `-d"ToolsDir=$toolsDir"` in Powershell v2.

Basically, the variables aren't being interpolated as we'd expect.

After trying various workaround, I've thrown in the towel and made a change to rewrite the template instead.

Now doing this:

![](http://cheaperthantherapy.me/wp-content/uploads/2013/03/drinking1.gif)

Oh, and made some changes to the `Get-ProjectItem` method to make it more robust and less procedural.

TODO:
- [x] test that Powershell V3 isn't impacted by these changes
- [x] kill off the verb warnings in `commands.psm1'
