### PR TITLE
WIP - fixing some edge case issues with uninstall

### DIFF
--- a/Create-Release.ps1
+++ b/Create-Release.ps1
@@ -55,3 +55,7 @@ Write-Diagnostic "Running all the tests"
 
 . $scriptsFolder\Run-UnitTests.ps1
 . $scriptsFolder\Run-PowershellTests.ps1
+
+rm ${env:APPDATA}\Shimmer\ProjectWithContent*
+rm ${env:APPDATA}\Shimmer\SampleUpdatingApp*
+rm ${env:APPDATA}\Shimmer\theApp*

--- a/src/Shimmer.Client/InstallManager.cs
+++ b/src/Shimmer.Client/InstallManager.cs
@@ -16,7 +16,7 @@ namespace Shimmer.Client
     public interface IInstallManager
     {
         IObservable<List<string>> ExecuteInstall(string currentAssemblyDir, IPackage bundledPackageMetadata, IObserver<int> progress = null);
-        IObservable<Unit> ExecuteUninstall();
+        IObservable<Unit> ExecuteUninstall(Version version);
     }
 
     public class InstallManager : IInstallManager
@@ -145,11 +145,11 @@ namespace Shimmer.Client
             return ret;
         }
 
-        public IObservable<Unit> ExecuteUninstall()
+        public IObservable<Unit> ExecuteUninstall(Version version = null)
         {
             var updateManager = new UpdateManager("http://lol", BundledRelease.PackageName, FrameworkVersion.Net40, TargetRootDirectory);
 
-            return updateManager.FullUninstall()
+            return updateManager.FullUninstall(version)
                 .ObserveOn(RxApp.DeferredScheduler)
                 .Log(this, "Full uninstall")
                 .Finally(updateManager.Dispose);

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -216,16 +216,9 @@ namespace Shimmer.Client
 
         IObservable<Unit> fullUninstall(Version maxVersion)
         {
-            return
-                Observable.Start(() => cleanUpOldVersions(maxVersion), RxApp.TaskpoolScheduler)
-                .SelectMany(_ => Utility.DeleteDirectory(rootAppDirectory))
-                .Catch<Unit, Exception>(ex => {
-                    log.WarnException(
-                        "Full Uninstall failed to delete root dir, punting to next reboot", ex);
-                    return Observable.Start(
-                        () => Utility.DeleteDirectoryAtNextReboot(rootAppDirectory));
-                })
-                .Aggregate(Unit.Default, (acc, x) => acc); ;
+            return Observable.Start(() => cleanUpOldVersions(maxVersion),
+                        RxApp.TaskpoolScheduler)
+                .Aggregate(Unit.Default, (acc , x) => acc);
         }
 
         public void Dispose()

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -207,14 +207,15 @@ namespace Shimmer.Client
                 ReleaseEntry.BuildReleasesFile(PackageDirectory, fileSystem), RxApp.TaskpoolScheduler));
         }
 
-        public IObservable<Unit> FullUninstall()
+        public IObservable<Unit> FullUninstall(Version version = null)
         {
-            return acquireUpdateLock().SelectMany(_ => fullUninstall());
+            version = version ?? new Version(255, 255, 255, 255);
+
+            return acquireUpdateLock().SelectMany(_ => fullUninstall(version));
         }
 
-        IObservable<Unit> fullUninstall()
+        IObservable<Unit> fullUninstall(Version maxVersion)
         {
-            var maxVersion = new Version(255, 255, 255, 255);
             return
                 Observable.Start(() => cleanUpOldVersions(maxVersion), RxApp.TaskpoolScheduler)
                 .SelectMany(_ => Utility.DeleteDirectory(rootAppDirectory))

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -608,13 +608,21 @@ namespace Shimmer.Client
         {
             var di = fileSystem.GetDirectoryInfo(rootAppDirectory);
 
+            log.Info("cleanDeadVersions: for version {0}", currentVersion);
+
+            string currentVersionFolder = null;
+            if (currentVersion != null) {
+                currentVersionFolder = getDirectoryForRelease(currentVersion).Name;
+                log.Info("cleanDeadVersions: exclude folder {0}", currentVersionFolder);
+            }
+
             // NB: If we try to access a directory that has already been 
             // scheduled for deletion by MoveFileEx it throws what seems like
             // NT's only error code, ERROR_ACCESS_DENIED. Squelch errors that
             // come from here.
             return di.GetDirectories().ToObservable()
                 .Where(x => x.Name.ToLowerInvariant().Contains("app-"))
-                .Where(x => currentVersion != null ? x.Name != getDirectoryForRelease(currentVersion).Name : true)
+                .Where(x => x.Name != currentVersionFolder)
                 .SelectMany(x => Utility.DeleteDirectory(x.FullName, RxApp.TaskpoolScheduler))
                     .LoggedCatch<Unit, UpdateManager, UnauthorizedAccessException>(this, _ => Observable.Return(Unit.Default))
                 .Aggregate(Unit.Default, (acc, x) => acc);

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -216,8 +216,14 @@ namespace Shimmer.Client
 
         IObservable<Unit> fullUninstall(Version maxVersion)
         {
-            return Observable.Start(() => cleanUpOldVersions(maxVersion),
-                        RxApp.TaskpoolScheduler)
+            var previous =
+                Observable.Start(() => cleanUpOldVersions(maxVersion),
+                                 RxApp.TaskpoolScheduler);
+            var current =
+                Observable.Start(() => cleanupVersion(getDirectoryForRelease(maxVersion)),
+                                 RxApp.TaskpoolScheduler);
+
+            return previous.Merge(current)
                 .Aggregate(Unit.Default, (acc , x) => acc);
         }
 
@@ -523,21 +529,25 @@ namespace Shimmer.Client
                 .Where(x => x.Name.StartsWith("app-", StringComparison.InvariantCultureIgnoreCase))
                 .Where(x => getVersionFromFolderName(x.Name) <= newCurrentVersion)
                 .OrderBy(x => x.Name)
-                .SelectMany(oldAppRoot => {
-                    var path = oldAppRoot.FullName;
-                    var installerHooks = new InstallerHookOperations(fileSystem, applicationName);
+                .SelectMany(cleanupVersion);
+        }
 
-                    var ret = AppDomainHelper.ExecuteInNewAppDomain(path, installerHooks.RunAppSetupCleanups);
+        IEnumerable<ShortcutCreationRequest> cleanupVersion(DirectoryInfoBase oldAppRoot)
+        {
+            var path = oldAppRoot.FullName;
+            var installerHooks = new InstallerHookOperations(fileSystem, applicationName);
 
-                    try {
-                        Utility.DeleteDirectoryAtNextReboot(oldAppRoot.FullName);
-                    } catch (Exception ex) {
-                        var message = String.Format("Couldn't delete old app directory on next reboot {0}",
-                            oldAppRoot.FullName);
-                        log.WarnException(message, ex);
-                    }
-                    return ret;
-                });
+            var ret = AppDomainHelper.ExecuteInNewAppDomain(path, installerHooks.RunAppSetupCleanups);
+
+            try {
+                Utility.DeleteDirectoryAtNextReboot(oldAppRoot.FullName);
+            }
+            catch (Exception ex) {
+                var message = String.Format("Couldn't delete old app directory on next reboot {0}",
+                    oldAppRoot.FullName);
+                log.WarnException(message, ex);
+            }
+            return ret;
         }
 
         void fixPinnedExecutables(Version newCurrentVersion) 

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -517,7 +517,7 @@ namespace Shimmer.Client
         {
             var directory = fileSystem.GetDirectoryInfo(rootAppDirectory);
             if (!directory.Exists) {
-                log.Warn("The directory '{0}' does not exist", rootAppDirectory);
+                log.Warn("cleanUpOldVersions: the directory '{0}' does not exist", rootAppDirectory);
                 return Enumerable.Empty<ShortcutCreationRequest>();
             }
             

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -405,6 +405,8 @@ namespace Shimmer.Client
             // NB: We sort this list in order to guarantee that if a Net20
             // and a Net40 version of a DLL get shipped, we always end up
             // with the 4.0 version.
+            log.Info("Writing files to app directory: {0}", target.FullName);
+
             pkg.GetLibFiles().Where(x => pathIsInFrameworkProfile(x, appFrameworkVersion))
                              .OrderBy(x => x.Path)
                              .ForEach(x => CopyFileToLocation(target, x));
@@ -431,7 +433,6 @@ namespace Shimmer.Client
 
             using (var inf = x.GetStream())
             using (var of = fi.Open(FileMode.CreateNew, FileAccess.Write)) {
-                log.Debug("Writing {0} to app directory", targetPath);
                 inf.CopyTo(of);
             }
         }

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -507,6 +507,10 @@ namespace Shimmer.Client
             });
         }
 
+        static Version getVersionFromFolderName(string name) {
+            return new Version(name.Substring(4)); // HACK HACK HACK
+        }
+
         IEnumerable<ShortcutCreationRequest> cleanUpOldVersions(Version newCurrentVersion)
         {
             var directory = fileSystem.GetDirectoryInfo(rootAppDirectory);
@@ -517,7 +521,7 @@ namespace Shimmer.Client
             
             return directory.GetDirectories()
                 .Where(x => x.Name.StartsWith("app-", StringComparison.InvariantCultureIgnoreCase))
-                .Where(x => x.Name != "app-" + newCurrentVersion)
+                .Where(x => getVersionFromFolderName(x.Name) <= newCurrentVersion)
                 .OrderBy(x => x.Name)
                 .SelectMany(oldAppRoot => {
                     var path = oldAppRoot.FullName;

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -534,7 +534,13 @@ namespace Shimmer.Client
 
         IEnumerable<ShortcutCreationRequest> cleanupVersion(DirectoryInfoBase oldAppRoot)
         {
+            if (!oldAppRoot.Exists) {
+                log.Warn("cleanUpOldVersions: the directory '{0}' does not exist", oldAppRoot.FullName);
+                return Enumerable.Empty<ShortcutCreationRequest>();
+            }
+
             var path = oldAppRoot.FullName;
+
             var installerHooks = new InstallerHookOperations(fileSystem, applicationName);
 
             var ret = AppDomainHelper.ExecuteInNewAppDomain(path, installerHooks.RunAppSetupCleanups);

--- a/src/Shimmer.Core/ReactiveUIMicro/ReactiveUI/Logging.cs
+++ b/src/Shimmer.Core/ReactiveUIMicro/ReactiveUI/Logging.cs
@@ -149,7 +149,8 @@ namespace ReactiveUIMicro
 
         public FileLogger(string appName)
         {
-            var fileName = String.Format("{0}.txt", appName);
+            var id = Process.GetCurrentProcess().Id;
+            var fileName = String.Format("{0}-{1}.txt", appName, id);
             directoryPath = Path.Combine(
                                 Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                                 "Shimmer");

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -125,7 +125,7 @@ namespace Shimmer.Core
             Contract.Requires(!String.IsNullOrEmpty(directoryPath));
 
             if (!Directory.Exists(directoryPath)) {
-                Log().Warn("DeleteDirectoryAtNextReboot: does not exist - {0}", directoryPath);
+                Log().Warn("DeleteDirectory: does not exist - {0}", directoryPath);
                 return Observable.Return(Unit.Default);
             }
 

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -120,9 +120,11 @@ namespace Shimmer.Core
 
         public static IObservable<Unit> DeleteDirectory(string directoryPath, IScheduler scheduler = null)
         {
+            Contract.Requires(!String.IsNullOrEmpty(directoryPath));
+
             scheduler = scheduler ?? RxApp.TaskpoolScheduler;
 
-            Contract.Requires(!String.IsNullOrEmpty(directoryPath));
+            Log().Info("Starting to delete folder: {0}", directoryPath);
 
             if (!Directory.Exists(directoryPath)) {
                 Log().Warn("DeleteDirectory: does not exist - {0}", directoryPath);

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -214,7 +214,10 @@ namespace Shimmer.Core
         {
             if (MoveFileEx(name, null, MoveFileFlags.MOVEFILE_DELAY_UNTIL_REBOOT)) return;
 
-            Log().Error("safeDeleteFileAtNextReboot: failed - {0}", name);
+            // thank you, http://www.pinvoke.net/default.aspx/coredll.getlasterror
+            var lastError = Marshal.GetLastWin32Error();
+
+            Log().Error("safeDeleteFileAtNextReboot: failed - {0} - {1}", name, lastError);
         }
 
         static IRxUIFullLogger Log()

--- a/src/Shimmer.WiXUi/App.cs
+++ b/src/Shimmer.WiXUi/App.cs
@@ -28,8 +28,6 @@ namespace Shimmer.WiXUi
             RxApp.LoggerFactory = _ => new FileLogger("Shimmer") { Level = ReactiveUI.LogLevel.Info };
             ReactiveUIMicro.RxApp.ConfigureFileLogging(); // HACK: we can do better than this later
 
-            this.Log().Info("Bootstrapper started");
-
             theApp = new Application();
 
             // NB: These are mirrored instead of just exposing Command because
@@ -69,12 +67,9 @@ namespace Shimmer.WiXUi
 
         public void ShouldQuit()
         {
-            this.Log().Info("Bootstrapper finishing");
-
             if (Command.Display == Display.Full) {
                 // if we're in Full mode, we have a UI to close
-                uiDispatcher.Invoke(new Action(() =>
-                {
+                uiDispatcher.Invoke(new Action(() => {
                     theApp.MainWindow.Close();
                     theApp.Shutdown();
                     Engine.Quit(0);
@@ -83,8 +78,6 @@ namespace Shimmer.WiXUi
                 // otherwise just quit in the background
                 Engine.Quit(0);
             }
-
-
         }
 
         #region Extremely dull code to set up IWiXEvents

--- a/src/Shimmer.WiXUi/App.cs
+++ b/src/Shimmer.WiXUi/App.cs
@@ -71,14 +71,20 @@ namespace Shimmer.WiXUi
         {
             this.Log().Info("Bootstrapper finishing");
 
-            // NB: For some reason, we can't get DispatcherScheduler.Current
-            // here, WiX is doing something very strange post-apply
-            uiDispatcher.Invoke(new Action(() =>
-            {
-                theApp.MainWindow.Close();
-                theApp.Shutdown();
+            if (Command.Display == Display.Full) {
+                // if we're in Full mode, we have a UI to close
+                uiDispatcher.Invoke(new Action(() =>
+                {
+                    theApp.MainWindow.Close();
+                    theApp.Shutdown();
+                    Engine.Quit(0);
+                }));
+            } else {
+                // otherwise just quit in the background
                 Engine.Quit(0);
-            }));
+            }
+
+
         }
 
         #region Extremely dull code to set up IWiXEvents

--- a/src/Shimmer.WiXUi/FileLogger.cs
+++ b/src/Shimmer.WiXUi/FileLogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using ReactiveUI;
 
@@ -14,7 +15,8 @@ namespace Shimmer.WiXUi
 
         public FileLogger(string appName)
         {
-            var fileName = String.Format("{0}.txt", appName);
+            var id = Process.GetCurrentProcess().Id;
+            var fileName = String.Format("{0}-{1}.txt", appName, id);
             filePath = Path.Combine(LogDirectory, fileName);
             messageFormat = "{0} | {1} | {2}";
         }

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -101,6 +101,13 @@ namespace Shimmer.WiXUi.ViewModels
                 }
 
                 if (wixEvents.Action == LaunchAction.Uninstall) {
+
+                    if (wixEvents.DisplayMode != Display.Full) {
+                        this.Log().Info("Shimmer is doing a silent uninstall! Sneaky!");
+                        wixEvents.Engine.Plan(LaunchAction.Uninstall);
+                        return;
+                    }
+
                     this.Log().Info("Shimmer is doing an uninstall! Sadface!");
                     var uninstallVm = RxApp.GetService<IUninstallingViewModel>();
                     Router.Navigate.Execute(uninstallVm);

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -150,7 +150,10 @@ namespace Shimmer.WiXUi.ViewModels
                 }
 
                 if (wixEvents.Action == LaunchAction.Uninstall) {
-                    installManager.ExecuteUninstall().Subscribe(
+
+                    var version = BundledRelease.Version;
+
+                    installManager.ExecuteUninstall(version).Subscribe(
                         _ => wixEvents.Engine.Apply(wixEvents.MainWindowHwnd),
                         ex => UserError.Throw(new UserError("Failed to uninstall", ex.Message, innerException: ex)));
                     return;


### PR DESCRIPTION
Resolves #143 by bringing the :fire_engine: 

A bunch of assorted fixes:
- run a new installer on a system which already had the application installed
- log the Win32 message when MoveFileEx fails
- log files are suffixed with the process number - to help trace scenarios where install AND uninstall are involved
- uninstall step would always try and navigate to a ViewModel (only do this when Full)
- ShouldQuit would fail when a UI is not present
- log messages are less terrible than before
- [ ] the tests should pass
#### Test Plan
##### Reinstall the same version
- [ ] install version A, then install version A again. 

**Expected**
- A runs 
- A in Programs & Features list
- No other folders in `%LOCALAPPDATA%`
##### Reinstall and Restart
- [ ] install version A, then install version A+1 while app A is open. Close A and restart. Click shortcut.

**Expected**
- A remains open. 
- A+1 in Programs List & shortcut. 
- Folder A is around after install.
- A+1 is opened when clicking shortcut
- Folder A is removed after restart.
##### Multiple reinstalls in a session
- [ ] install version A, then version A+1. Open A+1 via shortcut. Install version A+2 while A+1 is open. Close A+1 and restart.

**Expected** 
- A, A+1 remain usable throughout installs
- A+2 in Programs List & shortcut. 
- Only folder A+2 is around after install.
- A+2 is opened when clicking shortcut
- Folder A, A+1 is removed after restart.
