### PR TITLE
Uninstall should actually uninstall

### DIFF
--- a/Create-Release.ps1
+++ b/Create-Release.ps1
@@ -55,3 +55,7 @@ Write-Diagnostic "Running all the tests"
 
 . $scriptsFolder\Run-UnitTests.ps1
 . $scriptsFolder\Run-PowershellTests.ps1
+
+rm ${env:APPDATA}\Shimmer\ProjectWithContent*
+rm ${env:APPDATA}\Shimmer\SampleUpdatingApp*
+rm ${env:APPDATA}\Shimmer\theApp*

--- a/src/Shimmer.Client/Extensions/PackageExtensions.cs
+++ b/src/Shimmer.Client/Extensions/PackageExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics.Contracts;
+using System.Linq;
+using NuGet;
+
+namespace Shimmer.Client.Extensions
+{
+    public static class PackageExtensions
+    {
+        public static FrameworkVersion DetectFrameworkVersion(this IPackage package)
+        {
+            Contract.Requires(package != null);
+
+            return package.GetFiles().Any(x => x.Path.Contains("lib") && x.Path.Contains("45"))
+                ? FrameworkVersion.Net45
+                : FrameworkVersion.Net40;
+        }
+    }
+}

--- a/src/Shimmer.Client/InstallManager.cs
+++ b/src/Shimmer.Client/InstallManager.cs
@@ -10,6 +10,7 @@ using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NuGet;
 using ReactiveUIMicro;
+using Shimmer.Client.Extensions;
 using Shimmer.Core;
 
 namespace Shimmer.Client
@@ -72,7 +73,7 @@ namespace Shimmer.Client
             bool ignoreDeltaUpdates = false,
             IObserver<int> progress = null)
         {
-            var fxVersion = determineFxVersionFromPackage(bundledPackageMetadata);
+            var fxVersion = bundledPackageMetadata.DetectFrameworkVersion();
 
             var eigenCheckProgress = new Subject<int>();
             var eigenCopyFileProgress = new Subject<int>();
@@ -167,15 +168,6 @@ namespace Shimmer.Client
                 .ObserveOn(RxApp.DeferredScheduler)
                 .Log(this, "Full uninstall")
                 .Finally(updateManager.Dispose);
-        }
-
-        static FrameworkVersion determineFxVersionFromPackage(IPackage package)
-        {
-            Contract.Requires(package != null);
-
-            return package.GetFiles().Any(x => x.Path.Contains("lib") && x.Path.Contains("45"))
-                ? FrameworkVersion.Net45
-                : FrameworkVersion.Net40;
         }
     }
 }

--- a/src/Shimmer.Client/InstallManager.cs
+++ b/src/Shimmer.Client/InstallManager.cs
@@ -18,7 +18,7 @@ namespace Shimmer.Client
     public interface IInstallManager
     {
         IObservable<List<string>> ExecuteInstall(string currentAssemblyDir, IPackage bundledPackageMetadata, IObserver<int> progress = null);
-        IObservable<Unit> ExecuteUninstall();
+        IObservable<Unit> ExecuteUninstall(Version version);
     }
 
     public class InstallManager : IInstallManager
@@ -160,11 +160,11 @@ namespace Shimmer.Client
             return ret;
         }
 
-        public IObservable<Unit> ExecuteUninstall()
+        public IObservable<Unit> ExecuteUninstall(Version version = null)
         {
             var updateManager = new UpdateManager("http://lol", BundledRelease.PackageName, FrameworkVersion.Net40, TargetRootDirectory);
 
-            return updateManager.FullUninstall(BundledRelease.Version)
+            return updateManager.FullUninstall(version)
                 .ObserveOn(RxApp.DeferredScheduler)
                 .Log(this, "Full uninstall")
                 .Finally(updateManager.Dispose);

--- a/src/Shimmer.Client/InstallManager.cs
+++ b/src/Shimmer.Client/InstallManager.cs
@@ -164,7 +164,7 @@ namespace Shimmer.Client
         {
             var updateManager = new UpdateManager("http://lol", BundledRelease.PackageName, FrameworkVersion.Net40, TargetRootDirectory);
 
-            return updateManager.FullUninstall()
+            return updateManager.FullUninstall(BundledRelease.Version)
                 .ObserveOn(RxApp.DeferredScheduler)
                 .Log(this, "Full uninstall")
                 .Finally(updateManager.Dispose);

--- a/src/Shimmer.Client/InstallerHookOperations.cs
+++ b/src/Shimmer.Client/InstallerHookOperations.cs
@@ -170,6 +170,7 @@ namespace Shimmer.Client
             }
 
             var locatedAppSetups = allExeFiles
+                .Where(f => f.Exists)
                 .Select(x => loadAssemblyOrWhine(x.FullName)).Where(x => x != null)
                 .SelectMany(x => x.GetModules())
                 .SelectMany(x => {

--- a/src/Shimmer.Client/InstallerHookOperations.cs
+++ b/src/Shimmer.Client/InstallerHookOperations.cs
@@ -153,8 +153,15 @@ namespace Shimmer.Client
         {
             var allExeFiles = default(FileInfoBase[]);
 
+            var directory = fileSystem.GetDirectoryInfo(appDirectory);
+
+            if (!directory.Exists) {
+                log.Warn("findAppSetupsToRun: the folder {0} does not exist", appDirectory);
+                return Enumerable.Empty<IAppSetup>();
+            }
+
             try {
-                allExeFiles = fileSystem.GetDirectoryInfo(appDirectory).GetFiles("*.exe");
+                allExeFiles = directory.GetFiles("*.exe");
             } catch (UnauthorizedAccessException ex) {
                 // NB: This can happen if we run into a MoveFileEx'd directory,
                 // where we can't even get the list of files in it.

--- a/src/Shimmer.Client/Shimmer.Client.csproj
+++ b/src/Shimmer.Client/Shimmer.Client.csproj
@@ -134,6 +134,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BitsManager.cs" />
+    <Compile Include="Extensions\PackageExtensions.cs" />
     <Compile Include="IAppSetup.cs" />
     <Compile Include="InstallerHookOperations.cs" />
     <Compile Include="InstallManager.cs" />

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -410,6 +410,8 @@ namespace Shimmer.Client
             // NB: We sort this list in order to guarantee that if a Net20
             // and a Net40 version of a DLL get shipped, we always end up
             // with the 4.0 version.
+            log.Info("Writing files to app directory: {0}", target.FullName);
+
             pkg.GetLibFiles().Where(x => pathIsInFrameworkProfile(x, appFrameworkVersion))
                              .OrderBy(x => x.Path)
                              .ForEach(x => CopyFileToLocation(target, x));
@@ -436,7 +438,6 @@ namespace Shimmer.Client
 
             using (var inf = x.GetStream())
             using (var of = fi.Open(FileMode.CreateNew, FileAccess.Write)) {
-                log.Debug("Writing {0} to app directory", targetPath);
                 inf.CopyTo(of);
             }
         }

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -522,7 +522,7 @@ namespace Shimmer.Client
         {
             var directory = fileSystem.GetDirectoryInfo(rootAppDirectory);
             if (!directory.Exists) {
-                log.Warn("The directory '{0}' does not exist", rootAppDirectory);
+                log.Warn("cleanUpOldVersions: the directory '{0}' does not exist", rootAppDirectory);
                 return Enumerable.Empty<ShortcutCreationRequest>();
             }
             

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -218,6 +218,10 @@ namespace Shimmer.Client
         IEnumerable<DirectoryInfoBase> getReleases()
         {
             var rootDirectory = fileSystem.GetDirectoryInfo(rootAppDirectory);
+
+            if (!rootDirectory.Exists)
+                return Enumerable.Empty<DirectoryInfoBase>();
+
             return rootDirectory.GetDirectories()
                         .Where(x => x.Name.StartsWith("app-", StringComparison.InvariantCultureIgnoreCase));
         }

--- a/src/Shimmer.Core/Extensions/ReleaseExtensions.cs
+++ b/src/Shimmer.Core/Extensions/ReleaseExtensions.cs
@@ -45,5 +45,17 @@ namespace Shimmer.Core.Extensions
 
             return null;
         }
+
+        public static bool IsLessThanOrEqualTo(this string name, Version version)
+        {
+            var specificVersion = name.ToVersion();
+            return specificVersion <= version;
+        }
+
+        public static bool IsGreaterThan(this string name, Version version)
+        {
+            var specificVersion = name.ToVersion();
+            return specificVersion > version;
+        }
     }
 }

--- a/src/Shimmer.Core/Extensions/ReleaseExtensions.cs
+++ b/src/Shimmer.Core/Extensions/ReleaseExtensions.cs
@@ -45,17 +45,5 @@ namespace Shimmer.Core.Extensions
 
             return null;
         }
-
-        public static bool IsLessThanOrEqualTo(this string name, Version version)
-        {
-            var specificVersion = name.ToVersion();
-            return specificVersion <= version;
-        }
-
-        public static bool IsGreaterThan(this string name, Version version)
-        {
-            var specificVersion = name.ToVersion();
-            return specificVersion > version;
-        }
     }
 }

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -125,7 +125,7 @@ namespace Shimmer.Core
             Contract.Requires(!String.IsNullOrEmpty(directoryPath));
 
             if (!Directory.Exists(directoryPath)) {
-                Log().Warn("DeleteDirectoryAtNextReboot: does not exist - {0}", directoryPath);
+                Log().Warn("DeleteDirectory: does not exist - {0}", directoryPath);
                 return Observable.Return(Unit.Default);
             }
 

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -120,9 +120,11 @@ namespace Shimmer.Core
 
         public static IObservable<Unit> DeleteDirectory(string directoryPath, IScheduler scheduler = null)
         {
+            Contract.Requires(!String.IsNullOrEmpty(directoryPath));
+
             scheduler = scheduler ?? RxApp.TaskpoolScheduler;
 
-            Contract.Requires(!String.IsNullOrEmpty(directoryPath));
+            Log().Info("Starting to delete folder: {0}", directoryPath);
 
             if (!Directory.Exists(directoryPath)) {
                 Log().Warn("DeleteDirectory: does not exist - {0}", directoryPath);

--- a/src/Shimmer.Core/Utility.cs
+++ b/src/Shimmer.Core/Utility.cs
@@ -214,7 +214,10 @@ namespace Shimmer.Core
         {
             if (MoveFileEx(name, null, MoveFileFlags.MOVEFILE_DELAY_UNTIL_REBOOT)) return;
 
-            Log().Error("safeDeleteFileAtNextReboot: failed - {0}", name);
+            // thank you, http://www.pinvoke.net/default.aspx/coredll.getlasterror
+            var lastError = Marshal.GetLastWin32Error();
+
+            Log().Error("safeDeleteFileAtNextReboot: failed - {0} - {1}", name, lastError);
         }
 
         static IRxUIFullLogger Log()

--- a/src/Shimmer.Tests/Client/PackageExtensionsTests.cs
+++ b/src/Shimmer.Tests/Client/PackageExtensionsTests.cs
@@ -1,0 +1,24 @@
+﻿using NuGet;
+using Shimmer.Client;
+using Shimmer.Client.Extensions;
+using Shimmer.Tests.TestHelpers;
+using Xunit.Extensions;
+using Assert = Xunit.Assert;
+
+namespace Shimmer.Tests.Client
+{
+    public class PackageExtensionsTests
+    {
+        [Theory]
+        [InlineData("Shimmer.Core.1.0.0.0-full.nupkg", FrameworkVersion.Net40)]
+        [InlineData("Caliburn.Micro.1.5.2.nupkg", FrameworkVersion.Net45)]
+        public void DetectFrameworkVersion(string packageName, FrameworkVersion expected)
+        {
+            var path = IntegrationTestHelper.GetPath("fixtures", packageName);
+
+            var zip = new ZipPackage(path);
+
+            Assert.Equal(expected, zip.DetectFrameworkVersion());
+        }
+    }
+}

--- a/src/Shimmer.Tests/Shimmer.Tests.csproj
+++ b/src/Shimmer.Tests/Shimmer.Tests.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Client\CheckForUpdateTests.cs" />
     <Compile Include="Client\DownloadReleasesTests.cs" />
     <Compile Include="Client\InstallManagerTests.cs" />
+    <Compile Include="Client\PackageExtensionsTests.cs" />
     <Compile Include="Client\UpdateManagerTests.cs" />
     <Compile Include="Core\AppDomainHelperTests.cs" />
     <Compile Include="Core\ContentTypeTests.cs" />

--- a/src/Shimmer.Tests/TestHelpers/MoqExtensions.cs
+++ b/src/Shimmer.Tests/TestHelpers/MoqExtensions.cs
@@ -23,7 +23,7 @@ namespace Shimmer.Tests.TestHelpers
             mock.Setup(action)
                 .Callback(() => autoResetEvent.Set());
 
-            autoResetEvent.WaitOne(TimeSpan.FromSeconds(30));
+            autoResetEvent.WaitOne(TimeSpan.FromSeconds(10));
         }
     }
 }

--- a/src/Shimmer.Tests/WiXUi/WiXUiBootstrapperTests.cs
+++ b/src/Shimmer.Tests/WiXUi/WiXUiBootstrapperTests.cs
@@ -126,30 +126,7 @@ namespace Shimmer.Tests.WiXUi
             using (IntegrationTestHelper.WithFakeInstallDirectory(out dir))
             {
                 // install version 1
-                var kernel = new TinyIoCContainer();
-                kernel.Register(Mock.Of<IProcessFactory>());
-
-                var router = new RoutingState();
-                var detectPackage = new Subject<DetectPackageCompleteEventArgs>();
-                var planComplete = new Subject<PlanCompleteEventArgs>();
-                var applyComplete = new Subject<ApplyCompleteEventArgs>();
-                var error = new Subject<ErrorEventArgs>();
-                var engine = new Mock<IEngine>();
-
-                var events = new Mock<IWiXEvents>();
-                events.SetupGet(x => x.DetectPackageCompleteObs).Returns(detectPackage);
-                events.SetupGet(x => x.ErrorObs).Returns(error);
-                events.SetupGet(x => x.PlanCompleteObs).Returns(planComplete);
-                events.SetupGet(x => x.ApplyCompleteObs).Returns(applyComplete);
-                events.SetupGet(x => x.Engine).Returns(engine.Object);
-
-                events.SetupGet(x => x.DisplayMode).Returns(Display.Full);
-                events.SetupGet(x => x.Action).Returns(LaunchAction.Install);
-
-                var fixture = new WixUiBootstrapper(events.Object, kernel, router, null, dir, targetRootDirectory);
-                RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
-
-                mockPerformInstall(router, detectPackage, planComplete, applyComplete, engine);
+                mockPerformInstall(dir, targetRootDirectory);
 
                 Assert.True(Directory.Exists(Path.Combine(targetRootDirectory, "SampleUpdatingApp", "app-1.1.0.0")));
             }
@@ -237,32 +214,9 @@ namespace Shimmer.Tests.WiXUi
             string dir, targetRootDirectory;
             using (Utility.WithTempDirectory(out targetRootDirectory)) {
                 using (IntegrationTestHelper.WithFakeInstallDirectory("SampleUpdatingApp.1.0.0.0.nupkg", out dir)) {
+
                     // install version 1
-                    var firstKernel = new TinyIoCContainer();
-                    var firstFactory = new Mock<IProcessFactory>();
-                    firstKernel.Register(firstFactory.Object);
-
-                    var firstRouter = new RoutingState();
-                    var firstDetectPackage = new Subject<DetectPackageCompleteEventArgs>();
-                    var firstPlanComplete = new Subject<PlanCompleteEventArgs>();
-                    var firstApplyComplete = new Subject<ApplyCompleteEventArgs>();
-                    var firstError = new Subject<ErrorEventArgs>();
-                    var firstEngine = new Mock<IEngine>();
-
-                    var firstEvents = new Mock<IWiXEvents>();
-                    firstEvents.SetupGet(x => x.DetectPackageCompleteObs).Returns(firstDetectPackage);
-                    firstEvents.SetupGet(x => x.ErrorObs).Returns(firstError);
-                    firstEvents.SetupGet(x => x.PlanCompleteObs).Returns(firstPlanComplete);
-                    firstEvents.SetupGet(x => x.ApplyCompleteObs).Returns(firstApplyComplete);
-                    firstEvents.SetupGet(x => x.Engine).Returns(firstEngine.Object);
-
-                    firstEvents.SetupGet(x => x.DisplayMode).Returns(Display.Full);
-                    firstEvents.SetupGet(x => x.Action).Returns(LaunchAction.Install);
-
-                    var firstFixture = new WixUiBootstrapper(firstEvents.Object, firstKernel, firstRouter, null, dir,
-                        targetRootDirectory);
-
-                    mockPerformInstall(firstRouter, firstDetectPackage, firstPlanComplete, firstApplyComplete, firstEngine);
+                    mockPerformInstall(dir, targetRootDirectory);
                 }
 
                 using (IntegrationTestHelper.WithFakeInstallDirectory("SampleUpdatingApp.1.1.0.0.nupkg", out dir)) {
@@ -316,31 +270,7 @@ namespace Shimmer.Tests.WiXUi
                 var currentVersionFolder = Path.Combine(targetRootDirectory, "SampleUpdatingApp", "app-1.1.0.0");
 
                 // install version 1.1
-                var firstKernel = new TinyIoCContainer();
-                var firstFactory = new Mock<IProcessFactory>();
-                firstKernel.Register(firstFactory.Object);
-
-                var firstRouter = new RoutingState();
-                var firstDetectPackage = new Subject<DetectPackageCompleteEventArgs>();
-                var firstPlanComplete = new Subject<PlanCompleteEventArgs>();
-                var firstApplyComplete = new Subject<ApplyCompleteEventArgs>();
-                var firstError = new Subject<ErrorEventArgs>();
-                var firstEngine = new Mock<IEngine>();
-
-                var firstEvents = new Mock<IWiXEvents>();
-                firstEvents.SetupGet(x => x.DetectPackageCompleteObs).Returns(firstDetectPackage);
-                firstEvents.SetupGet(x => x.ErrorObs).Returns(firstError);
-                firstEvents.SetupGet(x => x.PlanCompleteObs).Returns(firstPlanComplete);
-                firstEvents.SetupGet(x => x.ApplyCompleteObs).Returns(firstApplyComplete);
-                firstEvents.SetupGet(x => x.Engine).Returns(firstEngine.Object);
-
-                firstEvents.SetupGet(x => x.DisplayMode).Returns(Display.Full);
-                firstEvents.SetupGet(x => x.Action).Returns(LaunchAction.Install);
-
-                var firstFixture = new WixUiBootstrapper(firstEvents.Object, firstKernel, firstRouter, null, dir,
-                    targetRootDirectory);
-
-                mockPerformInstall(firstRouter, firstDetectPackage, firstPlanComplete, firstApplyComplete, firstEngine);
+                mockPerformInstall(dir, targetRootDirectory);
 
                 Assert.True(Directory.Exists(currentVersionFolder));
 
@@ -387,67 +317,22 @@ namespace Shimmer.Tests.WiXUi
                 using (IntegrationTestHelper.WithFakeInstallDirectory("SampleUpdatingApp.1.0.0.0.nupkg", out dir)) {
 
                     // install version 1
-                    var kernel = new TinyIoCContainer();
-                    kernel.Register(Mock.Of<IProcessFactory>());
-
-                    var router = new RoutingState();
-                    var detectPackage = new Subject<DetectPackageCompleteEventArgs>();
-                    var planComplete = new Subject<PlanCompleteEventArgs>();
-                    var applyComplete = new Subject<ApplyCompleteEventArgs>();
-                    var error = new Subject<ErrorEventArgs>();
-                    var engine = new Mock<IEngine>();
-
-                    var events = new Mock<IWiXEvents>();
-                    events.SetupGet(x => x.DetectPackageCompleteObs).Returns(detectPackage);
-                    events.SetupGet(x => x.ErrorObs).Returns(error);
-                    events.SetupGet(x => x.PlanCompleteObs).Returns(planComplete);
-                    events.SetupGet(x => x.ApplyCompleteObs).Returns(applyComplete);
-                    events.SetupGet(x => x.Engine).Returns(engine.Object);
-
-                    events.SetupGet(x => x.DisplayMode).Returns(Display.Full);
-                    events.SetupGet(x => x.Action).Returns(LaunchAction.Install);
-
-                    var firstInstaller = new WixUiBootstrapper(events.Object, kernel, router, null, dir,
-                        targetRootDirectory);
-
-                    mockPerformInstall(router, detectPackage, planComplete, applyComplete, engine);
+                    mockPerformInstall(dir, targetRootDirectory);
 
                     Assert.True(Directory.Exists(firstVersionDirectory));
                 }
 
                 using (IntegrationTestHelper.WithFakeInstallDirectory("SampleUpdatingApp.1.1.0.0.nupkg", out dir)) {
+
                     //  install version 1.1
-                    var kernel = new TinyIoCContainer();
-                    kernel.Register(Mock.Of<IProcessFactory>());
-
-                    var router = new RoutingState();
-                    var detectPackage = new Subject<DetectPackageCompleteEventArgs>();
-                    var planComplete = new Subject<PlanCompleteEventArgs>();
-                    var applyComplete = new Subject<ApplyCompleteEventArgs>();
-                    var error = new Subject<ErrorEventArgs>();
-                    var engine = new Mock<IEngine>();
-
-                    var events = new Mock<IWiXEvents>();
-                    events.SetupGet(x => x.DetectPackageCompleteObs).Returns(detectPackage);
-                    events.SetupGet(x => x.ErrorObs).Returns(error);
-                    events.SetupGet(x => x.PlanCompleteObs).Returns(planComplete);
-                    events.SetupGet(x => x.ApplyCompleteObs).Returns(applyComplete);
-                    events.SetupGet(x => x.Engine).Returns(engine.Object);
-
-                    events.SetupGet(x => x.DisplayMode).Returns(Display.Full);
-                    events.SetupGet(x => x.Action).Returns(LaunchAction.Install);
-
-                    var secondInstaller = new WixUiBootstrapper(events.Object, kernel, router, null, dir,
-                        targetRootDirectory);
-                    RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
-
-                    mockPerformInstall(router, detectPackage, planComplete, applyComplete, engine);
+                    mockPerformInstall(dir, targetRootDirectory);
 
                     Assert.True(Directory.Exists(firstVersionDirectory));
                     Assert.True(Directory.Exists(secondVersionDirectory));
                 }
 
                 using (IntegrationTestHelper.WithFakeInstallDirectory("SampleUpdatingApp.1.0.0.0.nupkg", out dir)) {
+
                     //  uninstall version 1.0
                     var kernel = new TinyIoCContainer();
                     kernel.Register(Mock.Of<IProcessFactory>());
@@ -494,6 +379,37 @@ namespace Shimmer.Tests.WiXUi
         public void DefaultTypesShouldntStepOnExtensionRegisteredTypes()
         {
             throw new NotImplementedException();
+        }
+
+        static void mockPerformInstall(
+            string installDirectory,
+            string targetRootDirectory)
+        {
+            var kernel = new TinyIoCContainer();
+            kernel.Register(Mock.Of<IProcessFactory>());
+
+            var router = new RoutingState();
+            var detectPackage = new Subject<DetectPackageCompleteEventArgs>();
+            var planComplete = new Subject<PlanCompleteEventArgs>();
+            var applyComplete = new Subject<ApplyCompleteEventArgs>();
+            var error = new Subject<ErrorEventArgs>();
+            var engine = new Mock<IEngine>();
+
+            var events = new Mock<IWiXEvents>();
+            events.SetupGet(x => x.DetectPackageCompleteObs).Returns(detectPackage);
+            events.SetupGet(x => x.ErrorObs).Returns(error);
+            events.SetupGet(x => x.PlanCompleteObs).Returns(planComplete);
+            events.SetupGet(x => x.ApplyCompleteObs).Returns(applyComplete);
+            events.SetupGet(x => x.Engine).Returns(engine.Object);
+
+            events.SetupGet(x => x.DisplayMode).Returns(Display.Full);
+            events.SetupGet(x => x.Action).Returns(LaunchAction.Install);
+
+            var installer = new WixUiBootstrapper(events.Object, kernel, router, null, installDirectory,
+                       targetRootDirectory);
+
+            mockPerformInstall(router, detectPackage, planComplete, applyComplete, engine);
+
         }
 
         static void mockPerformInstall(

--- a/src/Shimmer.Tests/WiXUi/WiXUiBootstrapperTests.cs
+++ b/src/Shimmer.Tests/WiXUi/WiXUiBootstrapperTests.cs
@@ -638,12 +638,6 @@ namespace Shimmer.Tests.WiXUi
         //
 
         [Fact(Skip = "TODO")]
-        public void DetermineFxVersionFromPackageTest()
-        {
-            throw new NotImplementedException();
-        }
-
-        [Fact(Skip = "TODO")]
         public void RegisterExtensionDllsFindsExtensions()
         {
             throw new NotImplementedException();

--- a/src/Shimmer.Tests/WiXUi/WiXUiBootstrapperTests.cs
+++ b/src/Shimmer.Tests/WiXUi/WiXUiBootstrapperTests.cs
@@ -1,21 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.IO.Abstractions;
-using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
-using System.Reactive;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Windows;
-using Ionic.Zip;
 using Microsoft.Tools.WindowsInstallerXml.Bootstrapper;
 using Moq;
-using NuGet;
 using ReactiveUI;
 using ReactiveUI.Routing;
 using Shimmer.Client.WiXUi;
@@ -137,45 +126,30 @@ namespace Shimmer.Tests.WiXUi
             using (IntegrationTestHelper.WithFakeInstallDirectory(out dir))
             {
                 // install version 1
-                var firstKernel = new TinyIoCContainer();
-                var firstFactory = new Mock<IProcessFactory>();
-                firstKernel.Register(firstFactory.Object);
+                var kernel = new TinyIoCContainer();
+                kernel.Register(Mock.Of<IProcessFactory>());
 
-                var firstRouter = new RoutingState();
-                var firstDetectPackage = new Subject<DetectPackageCompleteEventArgs>();
-                var firstPlanComplete = new Subject<PlanCompleteEventArgs>();
-                var firstApplyComplete = new Subject<ApplyCompleteEventArgs>();
-                var firstError = new Subject<ErrorEventArgs>();
-                var firstEngine = new Mock<IEngine>();
+                var router = new RoutingState();
+                var detectPackage = new Subject<DetectPackageCompleteEventArgs>();
+                var planComplete = new Subject<PlanCompleteEventArgs>();
+                var applyComplete = new Subject<ApplyCompleteEventArgs>();
+                var error = new Subject<ErrorEventArgs>();
+                var engine = new Mock<IEngine>();
 
-                var firstEvents = new Mock<IWiXEvents>();
-                firstEvents.SetupGet(x => x.DetectPackageCompleteObs).Returns(firstDetectPackage);
-                firstEvents.SetupGet(x => x.ErrorObs).Returns(firstError);
-                firstEvents.SetupGet(x => x.PlanCompleteObs).Returns(firstPlanComplete);
-                firstEvents.SetupGet(x => x.ApplyCompleteObs).Returns(firstApplyComplete);
-                firstEvents.SetupGet(x => x.Engine).Returns(firstEngine.Object);
+                var events = new Mock<IWiXEvents>();
+                events.SetupGet(x => x.DetectPackageCompleteObs).Returns(detectPackage);
+                events.SetupGet(x => x.ErrorObs).Returns(error);
+                events.SetupGet(x => x.PlanCompleteObs).Returns(planComplete);
+                events.SetupGet(x => x.ApplyCompleteObs).Returns(applyComplete);
+                events.SetupGet(x => x.Engine).Returns(engine.Object);
 
-                firstEvents.SetupGet(x => x.DisplayMode).Returns(Display.Full);
-                firstEvents.SetupGet(x => x.Action).Returns(LaunchAction.Install);
+                events.SetupGet(x => x.DisplayMode).Returns(Display.Full);
+                events.SetupGet(x => x.Action).Returns(LaunchAction.Install);
 
-                var firstFixture = new WixUiBootstrapper(firstEvents.Object, firstKernel, firstRouter, null, dir, targetRootDirectory);
+                var fixture = new WixUiBootstrapper(events.Object, kernel, router, null, dir, targetRootDirectory);
                 RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
-                // initialize the install process
-                firstDetectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Absent));
-
-                // navigate to the next VM
-                var viewModel = firstRouter.GetCurrentViewModel() as WelcomeViewModel;
-                viewModel.ShouldProceed.Execute(null);
-
-                // signal to start the install
-                firstPlanComplete.OnNext(new PlanCompleteEventArgs(0));
-
-                // wait until install is complete
-                firstEngine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
-
-                // now signal it's completed
-                firstApplyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+                mockPerformInstall(router, detectPackage, planComplete, applyComplete, engine);
 
                 Assert.True(Directory.Exists(Path.Combine(targetRootDirectory, "SampleUpdatingApp", "app-1.1.0.0")));
             }
@@ -213,21 +187,7 @@ namespace Shimmer.Tests.WiXUi
                 var firstFixture = new WixUiBootstrapper(firstEvents.Object, firstKernel, firstRouter, null, dir, targetRootDirectory);
                 RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
-                // initialize the install process
-                firstDetectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Absent));
-
-                // navigate to the next VM
-                var viewModel = firstRouter.GetCurrentViewModel() as WelcomeViewModel;
-                viewModel.ShouldProceed.Execute(null);
-
-                // signal to start the install
-                firstPlanComplete.OnNext(new PlanCompleteEventArgs(0));
-
-                // wait until install is complete
-                firstEngine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
-
-                // now signal it's completed
-                firstApplyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+                mockPerformInstall(firstRouter, firstDetectPackage, firstPlanComplete, firstApplyComplete, firstEngine);
 
                 // we expect that it opens the main exe
                 firstFactory.Verify(p => p.Start(It.IsAny<string>()), Times.Once());
@@ -255,23 +215,8 @@ namespace Shimmer.Tests.WiXUi
                 secondEvents.SetupGet(x => x.Action).Returns(LaunchAction.Install);
 
                 var secondFixture = new WixUiBootstrapper(secondEvents.Object, secondKernel, secondRouter, null, dir, targetRootDirectory);
-                RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
-                // initialize the install process
-                secondDetectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Absent));
-
-                // navigate to the next VM
-                viewModel = secondRouter.GetCurrentViewModel() as WelcomeViewModel;
-                viewModel.ShouldProceed.Execute(null);
-
-                // signal to start the install
-                secondPlanComplete.OnNext(new PlanCompleteEventArgs(0));
-
-                // wait until install is complete
-                secondEngine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
-
-                // now signal it's completed
-                secondApplyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+                mockPerformInstall(secondRouter, secondDetectPackage, secondPlanComplete, secondApplyComplete, secondEngine);
 
                 var folder = Path.Combine(targetRootDirectory, "SampleUpdatingApp", "app-1.1.0.0");
                 Assert.True(Directory.Exists(folder));
@@ -316,23 +261,8 @@ namespace Shimmer.Tests.WiXUi
 
                     var firstFixture = new WixUiBootstrapper(firstEvents.Object, firstKernel, firstRouter, null, dir,
                         targetRootDirectory);
-                    RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
-                    // initialize the install process
-                    firstDetectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Absent));
-
-                    // navigate to the next VM
-                    var viewModel = firstRouter.GetCurrentViewModel() as WelcomeViewModel;
-                    viewModel.ShouldProceed.Execute(null);
-
-                    // signal to start the install
-                    firstPlanComplete.OnNext(new PlanCompleteEventArgs(0));
-
-                    // wait until install is complete
-                    firstEngine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
-
-                    // now signal it's completed
-                    firstApplyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+                    mockPerformInstall(firstRouter, firstDetectPackage, firstPlanComplete, firstApplyComplete, firstEngine);
                 }
 
                 using (IntegrationTestHelper.WithFakeInstallDirectory("SampleUpdatingApp.1.1.0.0.nupkg", out dir)) {
@@ -359,23 +289,8 @@ namespace Shimmer.Tests.WiXUi
                     secondEvents.SetupGet(x => x.Action).Returns(LaunchAction.Install);
 
                     var secondFixture = new WixUiBootstrapper(secondEvents.Object, secondKernel, secondRouter, null, dir, targetRootDirectory);
-                    RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
-                    // initialize the install process
-                    secondDetectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Absent));
-
-                    // navigate to the next VM
-                    var viewModel = secondRouter.GetCurrentViewModel() as WelcomeViewModel;
-                    viewModel.ShouldProceed.Execute(null);
-
-                    // signal to start the install
-                    secondPlanComplete.OnNext(new PlanCompleteEventArgs(0));
-
-                    // wait until install is complete
-                    secondEngine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
-
-                    // now signal it's completed
-                    secondApplyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+                    mockPerformInstall(secondRouter, secondDetectPackage, secondPlanComplete, secondApplyComplete, secondEngine);
 
                     var folder = Path.Combine(targetRootDirectory, "SampleUpdatingApp", "app-1.1.0.0");
                     Assert.True(Directory.Exists(folder));
@@ -400,7 +315,7 @@ namespace Shimmer.Tests.WiXUi
 
                 var currentVersionFolder = Path.Combine(targetRootDirectory, "SampleUpdatingApp", "app-1.1.0.0");
 
-                // install version 1
+                // install version 1.1
                 var firstKernel = new TinyIoCContainer();
                 var firstFactory = new Mock<IProcessFactory>();
                 firstKernel.Register(firstFactory.Object);
@@ -424,23 +339,8 @@ namespace Shimmer.Tests.WiXUi
 
                 var firstFixture = new WixUiBootstrapper(firstEvents.Object, firstKernel, firstRouter, null, dir,
                     targetRootDirectory);
-                RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
-                // initialize the install process
-                firstDetectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Absent));
-
-                // navigate to the next VM
-                var viewModel = firstRouter.GetCurrentViewModel() as WelcomeViewModel;
-                viewModel.ShouldProceed.Execute(null);
-
-                // signal to start the install
-                firstPlanComplete.OnNext(new PlanCompleteEventArgs(0));
-
-                // wait until install is complete
-                firstEngine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
-
-                // now signal it's completed
-                firstApplyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+                mockPerformInstall(firstRouter, firstDetectPackage, firstPlanComplete, firstApplyComplete, firstEngine);
 
                 Assert.True(Directory.Exists(currentVersionFolder));
 
@@ -469,17 +369,7 @@ namespace Shimmer.Tests.WiXUi
                 var secondFixture = new WixUiBootstrapper(secondEvents.Object, secondKernel, secondRouter, null, dir, targetRootDirectory);
                 RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
-                // initialize the uninstall process
-                secondDetectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Present));
-
-                // signal to start the uninstall
-                secondPlanComplete.OnNext(new PlanCompleteEventArgs(0));
-
-                // wait until install is complete
-                secondEngine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
-
-                // now signal it's completed
-                secondApplyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+                mockPerformUninstall(secondDetectPackage, secondPlanComplete, secondApplyComplete, secondEngine);
 
                 Assert.False(Directory.Exists(currentVersionFolder));
             }
@@ -520,21 +410,7 @@ namespace Shimmer.Tests.WiXUi
                     var firstInstaller = new WixUiBootstrapper(events.Object, kernel, router, null, dir,
                         targetRootDirectory);
 
-                    // initialize the install process
-                    detectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Absent));
-
-                    // navigate to the next VM
-                    var viewModel = router.GetCurrentViewModel() as WelcomeViewModel;
-                    viewModel.ShouldProceed.Execute(null);
-
-                    // signal to start the install
-                    planComplete.OnNext(new PlanCompleteEventArgs(0));
-
-                    // wait until install is complete
-                    engine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
-
-                    // now signal it's completed
-                    applyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+                    mockPerformInstall(router, detectPackage, planComplete, applyComplete, engine);
 
                     Assert.True(Directory.Exists(firstVersionDirectory));
                 }
@@ -565,21 +441,7 @@ namespace Shimmer.Tests.WiXUi
                         targetRootDirectory);
                     RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
-                    // initialize the install process
-                    detectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Present));
-
-                    // navigate to the next VM
-                    var viewModel = router.GetCurrentViewModel() as WelcomeViewModel;
-                    viewModel.ShouldProceed.Execute(null);
-
-                    // signal to start the install
-                    planComplete.OnNext(new PlanCompleteEventArgs(0));
-
-                    // wait until install is complete
-                    engine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
-
-                    // now signal it's completed
-                    applyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+                    mockPerformInstall(router, detectPackage, planComplete, applyComplete, engine);
 
                     Assert.True(Directory.Exists(firstVersionDirectory));
                     Assert.True(Directory.Exists(secondVersionDirectory));
@@ -609,29 +471,14 @@ namespace Shimmer.Tests.WiXUi
 
                     var firstUninstallFixture = new WixUiBootstrapper(events.Object, kernel, router, null, dir,
                         targetRootDirectory);
-                    RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
-                    // initialize the uninstall process
-                    detectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Present));
-
-                    // signal to start the uninstall
-                    planComplete.OnNext(new PlanCompleteEventArgs(0));
-
-                    // wait until install is complete
-                    engine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
-
-                    // now signal it's completed
-                    applyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+                    mockPerformUninstall(detectPackage, planComplete, applyComplete, engine);
 
                     Assert.False(Directory.Exists(firstVersionDirectory), "The old version is not cleaned up as expected");
                     Assert.True(Directory.Exists(secondVersionDirectory), "The new version should persist after uninstalling the old version");
                 }
             }
         }
-
-        //
-        // PlanComplete
-        //
 
         //
         // Helper methods
@@ -647,6 +494,49 @@ namespace Shimmer.Tests.WiXUi
         public void DefaultTypesShouldntStepOnExtensionRegisteredTypes()
         {
             throw new NotImplementedException();
+        }
+
+        static void mockPerformInstall(
+          IRoutingState router,
+          IObserver<DetectPackageCompleteEventArgs> detectPackage,
+          IObserver<PlanCompleteEventArgs> planComplete,
+          IObserver<ApplyCompleteEventArgs> applyComplete,
+          Mock<IEngine> engine)
+        {
+            // initialize the install process
+            detectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Present));
+
+            // navigate to the next VM
+            var viewModel = router.GetCurrentViewModel() as WelcomeViewModel;
+            viewModel.ShouldProceed.Execute(null);
+
+            // signal to start the install
+            planComplete.OnNext(new PlanCompleteEventArgs(0));
+
+            // wait until install is complete
+            engine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
+
+            // now signal it's completed
+            applyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
+        }
+
+        static void mockPerformUninstall(
+          IObserver<DetectPackageCompleteEventArgs> detectPackage,
+          IObserver<PlanCompleteEventArgs> planComplete,
+          IObserver<ApplyCompleteEventArgs> applyComplete,
+          Mock<IEngine> engine)
+        {
+            // initialize the uninstall process
+            detectPackage.OnNext(new DetectPackageCompleteEventArgs("Foo", 0, PackageState.Present));
+
+            // signal to start the uninstall
+            planComplete.OnNext(new PlanCompleteEventArgs(0));
+
+            // wait until install is complete
+            engine.WaitUntil(e => e.Apply(It.IsAny<IntPtr>()));
+
+            // now signal it's completed
+            applyComplete.OnNext(new ApplyCompleteEventArgs(0, ApplyRestart.None));
         }
     }
 }

--- a/src/Shimmer.WiXUi/App.cs
+++ b/src/Shimmer.WiXUi/App.cs
@@ -73,14 +73,20 @@ namespace Shimmer.WiXUi
         {
             this.Log().Info("Bootstrapper finishing");
 
-            // NB: For some reason, we can't get DispatcherScheduler.Current
-            // here, WiX is doing something very strange post-apply
-            uiDispatcher.Invoke(new Action(() =>
-            {
-                theApp.MainWindow.Close();
-                theApp.Shutdown();
+            if (Command.Display == Display.Full) {
+                // if we're in Full mode, we have a UI to close
+                uiDispatcher.Invoke(new Action(() =>
+                {
+                    theApp.MainWindow.Close();
+                    theApp.Shutdown();
+                    Engine.Quit(0);
+                }));
+            } else {
+                // otherwise just quit in the background
                 Engine.Quit(0);
-            }));
+            }
+
+
         }
 
         #region Extremely dull code to set up IWiXEvents

--- a/src/Shimmer.WiXUi/App.cs
+++ b/src/Shimmer.WiXUi/App.cs
@@ -28,8 +28,6 @@ namespace Shimmer.WiXUi
             RxApp.LoggerFactory = _ => new FileLogger("Shimmer") { Level = ReactiveUI.LogLevel.Info };
             ReactiveUIMicro.RxApp.ConfigureFileLogging(); // HACK: we can do better than this later
 
-            this.Log().Info("Bootstrapper started");
-
             theApp = new Application();
 
             // NB: These are mirrored instead of just exposing Command because
@@ -71,12 +69,9 @@ namespace Shimmer.WiXUi
 
         public void ShouldQuit()
         {
-            this.Log().Info("Bootstrapper finishing");
-
             if (Command.Display == Display.Full) {
                 // if we're in Full mode, we have a UI to close
-                uiDispatcher.Invoke(new Action(() =>
-                {
+                uiDispatcher.Invoke(new Action(() => {
                     theApp.MainWindow.Close();
                     theApp.Shutdown();
                     Engine.Quit(0);
@@ -85,8 +80,6 @@ namespace Shimmer.WiXUi
                 // otherwise just quit in the background
                 Engine.Quit(0);
             }
-
-
         }
 
         #region Extremely dull code to set up IWiXEvents

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -159,8 +159,16 @@ namespace Shimmer.WiXUi.ViewModels
                     return;
                 }
 
+                // background uninstall - only remove this version
                 if (wixEvents.Action == LaunchAction.Uninstall) {
-                    installManager.ExecuteUninstall().Subscribe(
+
+                    var version = wixEvents.DisplayMode == Display.Embedded
+                        // Display.Embedded - only remove this version
+                        ? BundledRelease.Version
+                        // Display.Full - remove everything
+                        : null;
+
+                    installManager.ExecuteUninstall(version).Subscribe(
                         _ => wixEvents.Engine.Apply(wixEvents.MainWindowHwnd),
                         ex => UserError.Throw(new UserError("Failed to uninstall", ex.Message, innerException: ex)));
                     return;

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -109,6 +109,13 @@ namespace Shimmer.WiXUi.ViewModels
                 }
 
                 if (wixEvents.Action == LaunchAction.Uninstall) {
+
+                    if (wixEvents.DisplayMode != Display.Full) {
+                        this.Log().Info("Shimmer is doing a silent uninstall! Sneaky!");
+                        wixEvents.Engine.Plan(LaunchAction.Uninstall);
+                        return;
+                    }
+
                     this.Log().Info("Shimmer is doing an uninstall! Sadface!");
                     var uninstallVm = RxApp.GetService<IUninstallingViewModel>();
                     Router.Navigate.Execute(uninstallVm);

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -161,14 +161,7 @@ namespace Shimmer.WiXUi.ViewModels
 
                 // background uninstall - only remove this version
                 if (wixEvents.Action == LaunchAction.Uninstall) {
-
-                    var version = wixEvents.DisplayMode == Display.Embedded
-                        // Display.Embedded - only remove this version
-                        ? BundledRelease.Version
-                        // Display.Full - remove everything
-                        : null;
-
-                    installManager.ExecuteUninstall(version).Subscribe(
+                    installManager.ExecuteUninstall(BundledRelease.Version).Subscribe(
                         _ => wixEvents.Engine.Apply(wixEvents.MainWindowHwnd),
                         ex => UserError.Throw(new UserError("Failed to uninstall", ex.Message, innerException: ex)));
                     return;

--- a/src/Shimmer.WiXUi/WixUiBootstrapper.cs
+++ b/src/Shimmer.WiXUi/WixUiBootstrapper.cs
@@ -161,9 +161,11 @@ namespace Shimmer.WiXUi.ViewModels
 
                 // background uninstall - only remove this version
                 if (wixEvents.Action == LaunchAction.Uninstall) {
-                    installManager.ExecuteUninstall(BundledRelease.Version).Subscribe(
+                    var task = installManager.ExecuteUninstall(BundledRelease.Version);
+                    task.Subscribe(
                         _ => wixEvents.Engine.Apply(wixEvents.MainWindowHwnd),
                         ex => UserError.Throw(new UserError("Failed to uninstall", ex.Message, innerException: ex)));
+                    task.Wait();
                     return;
                 }
 


### PR DESCRIPTION
Little things:
- Fixed up some bugs with how WiX triggers uninstall
  - occurs in background, so no dispatcher present
  - don't show the ViewModel when in background
- Check the Win32 exception when MOVEFILE_DELAY_UNTIL_REBOOT fails
- `Create-Release` cleans up the test logs
- testing our package detection code

Bigger things:
- the uninstall step should not throw an exception about incorrectly disposing resources
- running a newer installer should tidy up the old installer (from Windows mostly)

TODO:
- [x] when an old installer runs and uninstalls itself, do not clobber later versions (i.e make the test pass)
- [x] some issue with not disposing UpdateManager properly when running the second installer
- [x] investigate why the uninstall steps are throwing a FileNotFoundException (race condition? awesome!)
- [x] get to the bottom of why the uninstall seems to succeed but doesn't
