### PR TITLE
CheckForUpdate should never return null

### DIFF
--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -303,7 +303,12 @@ namespace Shimmer.Client
 
             if (localReleases.Count() == remoteReleases.Count()) {
                 log.Info("No updates, remote and local are the same");
-                return Observable.Return<UpdateInfo>(null);
+
+                var latestFullRelease = findCurrentVersion(remoteReleases);
+                var currentRelease = findCurrentVersion(localReleases);
+
+                var info = UpdateInfo.Create(currentRelease, new[] {latestFullRelease}, PackageDirectory,appFrameworkVersion);
+                return Observable.Return(info);
             }
 
             if (ignoreDeltaUpdates) {

--- a/src/Shimmer.Tests/Client/UpdateManagerTests.cs
+++ b/src/Shimmer.Tests/Client/UpdateManagerTests.cs
@@ -78,7 +78,8 @@ namespace Shimmer.Tests.Client
                         updateInfo = fixture.CheckForUpdate().Wait();
                     }
 
-                    Assert.Null(updateInfo);
+                    Assert.NotNull(updateInfo);
+                    Assert.Empty(updateInfo.ReleasesToApply);
                 }
             }
 


### PR DESCRIPTION
`UpdateManager.CheckForUpdate` should always return a result.

This makes sure of that.
