### PR TITLE
Don't annoy the user when updating the NuGet package for Shimmer

### DIFF
--- a/src/CreateReleasePackage/tools/Install.ps1
+++ b/src/CreateReleasePackage/tools/Install.ps1
@@ -19,9 +19,9 @@ function Initialize-Shimmer {
     $projectDir = (gci $project.FullName).Directory
     $nuspecFile = (Join-Path $projectDir "$ProjectName.nuspec")
 
-    Write-Message "Initializing project $ProjectName for installer and packaging"
-
     if (!(Test-Path $nuspecFile)) {
+        Write-Message "Initializing project $ProjectName for installer and packaging"
+
         Add-InstallerTemplate -Destination $nuspecFile -ProjectName $ProjectName
 
         Set-BuildPackage -Value $true -ProjectName $ProjectName
@@ -30,6 +30,10 @@ function Initialize-Shimmer {
 
         # open the nuspec file in the editor
         $dte.ItemOperations.OpenFile($nuspecFile) | Out-Null
+    } else {
+        Write-Message "You already have a nuspec file defined, no changes applied"
+
+        Write-Message "Run 'Enable-BuildPackage' to enable package creation for a project"
     }
 }
 

--- a/src/CreateReleasePackage/tools/Install.ps1
+++ b/src/CreateReleasePackage/tools/Install.ps1
@@ -21,14 +21,16 @@ function Initialize-Shimmer {
 
     Write-Message "Initializing project $ProjectName for installer and packaging"
 
-    Add-InstallerTemplate -Destination $nuspecFile -ProjectName $ProjectName
+    if (!(Test-Path $nuspecFile)) {
+        Add-InstallerTemplate -Destination $nuspecFile -ProjectName $ProjectName
 
-    Set-BuildPackage -Value $true -ProjectName $ProjectName
+        Set-BuildPackage -Value $true -ProjectName $ProjectName
 
-    Add-FileWithNoOutput -FilePath $nuspecFile -Project $Project
+        Add-FileWithNoOutput -FilePath $nuspecFile -Project $Project
 
-    # open the nuspec file in the editor
-    $dte.ItemOperations.OpenFile($nuspecFile) | Out-Null
+        # open the nuspec file in the editor
+        $dte.ItemOperations.OpenFile($nuspecFile) | Out-Null
+    }
 }
 
 Write-Message "Now to setup the project - so you don't have to..."

--- a/src/CreateReleasePackage/tools/visualstudio.psm1
+++ b/src/CreateReleasePackage/tools/visualstudio.psm1
@@ -32,8 +32,20 @@ function New-Release {
                              -BuildDir (Join-Path $projectDir $outputDir)
 }
 
-Register-TabExpansion 'New-Release' @{
-        ProjectName = { Get-Project -All | Select -ExpandProperty Name }
+function Enable-BuildPackage {
+    [CmdletBinding()]
+    param (
+        [Parameter(Position=0, ValueFromPipeLine=$true)]
+        [string] $ProjectName
+    )
+
+        Set-BuildPackage -Value $true -ProjectName $ProjectName
 }
 
-Export-ModuleMember New-Release
+'New-Release', 'Enable-BuildPackage' | %{
+    Register-TabExpansion $_ @{
+        ProjectName = { Get-Project -All | Select -ExpandProperty Name }
+    }
+}
+
+Export-ModuleMember New-Release, Enable-BuildPackage


### PR DESCRIPTION
Resolves #150 and also resolves #129 

Need to test this a bit more thoroughly, but it all works in my head.

Basically, when you upgrade the package it won't do anything silly if your nuspec file exists.

cc @peters if you want to confirm this is to your liking
