### PR TITLE
switched file logging to %LOCALAPPDATA%

### DIFF
--- a/src/Shimmer.Core/ReactiveUIMicro/ReactiveUI/Logging.cs
+++ b/src/Shimmer.Core/ReactiveUIMicro/ReactiveUI/Logging.cs
@@ -152,7 +152,7 @@ namespace ReactiveUIMicro
             var id = Process.GetCurrentProcess().Id;
             var fileName = String.Format("{0}-{1}.txt", appName, id);
             directoryPath = Path.Combine(
-                                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                                 "Shimmer");
             filePath = Path.Combine(directoryPath, fileName);
 

--- a/src/Shimmer.WiXUi/FileLogger.cs
+++ b/src/Shimmer.WiXUi/FileLogger.cs
@@ -23,7 +23,7 @@ namespace Shimmer.WiXUi
         public static string LogDirectory {
             get {
                 return Path.Combine(
-                               Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                               Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                                "Shimmer");
             }
         }


### PR DESCRIPTION
Because we don't need to sync Shimmer logs between machines, this change switches it over to just use `%LOCALAPPDATA%`

Quick explanation:

> `Roaming` is the folder that would be synchronized with a server if you logged into a domain with a roaming profile (enabling you to log into any computer in a domain and access your favorites, documents, etc. Firefox stores its information here, so you could even have the same bookmarks between computers with a roaming profile.
