### PR TITLE
Are shortcuts broken? 

### DIFF
--- a/src/Shimmer.Core/ReactiveUIMicro/Rx-Shim/AwaitableAsyncSubject.cs
+++ b/src/Shimmer.Core/ReactiveUIMicro/Rx-Shim/AwaitableAsyncSubject.cs
@@ -330,7 +330,7 @@ namespace ReactiveUIMicro
             }
 
             if (_exception != null) {
-                throw _exception;
+                throw new InvalidOperationException("AwaitableAsyncSubject<T>.GetResult() is rethrowing an inner exception", _exception);
             }
 
             if (!_hasValue)


### PR DESCRIPTION
Improving error handling in specific spots to isolate #141 
- `fixPinnedExecutables` isolates two possible headaches with parsing shell links and logs exceptions
- `runPostInstallAndCleanup` indicates when it finishes the `fixPinnedExecutables`
- `AsyncAwaitableSubject` should keep the inner exception's stacktrace
