### PR TITLE
With that shortcut issue identified, let's tidy up a bit

### DIFF
--- a/src/Shimmer.Client/DidntFollowInstructionsAppSetup.cs
+++ b/src/Shimmer.Client/DidntFollowInstructionsAppSetup.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+
+namespace Shimmer.Client
+{
+    public class DidntFollowInstructionsAppSetup : AppSetup
+    {
+        readonly string shortCutName;
+        public override string ShortcutName {
+            get { return shortCutName; }
+        }
+
+        readonly string target;
+        public override string Target { get { return target; } }
+
+        public DidntFollowInstructionsAppSetup(string exeFile)
+        {
+            var fvi = FileVersionInfo.GetVersionInfo(exeFile);
+            shortCutName = fvi.ProductName ?? fvi.FileDescription ?? fvi.FileName.Replace(".exe", "");
+            target = exeFile;
+        }
+    }
+}

--- a/src/Shimmer.Client/Shimmer.Client.csproj
+++ b/src/Shimmer.Client/Shimmer.Client.csproj
@@ -134,6 +134,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BitsManager.cs" />
+    <Compile Include="DidntFollowInstructionsAppSetup.cs" />
     <Compile Include="Extensions\PackageExtensions.cs" />
     <Compile Include="IAppSetup.cs" />
     <Compile Include="InstallerHookOperations.cs" />

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -603,7 +603,7 @@ namespace Shimmer.Client
 
             if (!oldAppDirectories.Any()) {
                 log.Info("fixPinnedExecutables: oldAppDirectories is empty, this is pointless");
-                // TODO: return here?
+                return;
             }
 
             var newAppPath = Path.Combine(rootAppDirectory, "app-" + newCurrentVersion);

--- a/src/Shimmer.Client/UpdateManager.cs
+++ b/src/Shimmer.Client/UpdateManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.IO.Abstractions;
 using System.Linq;
@@ -698,24 +697,6 @@ namespace Shimmer.Client
                 .SelectMany(x => Utility.DeleteDirectory(x.FullName, RxApp.TaskpoolScheduler))
                     .LoggedCatch<Unit, UpdateManager, UnauthorizedAccessException>(this, _ => Observable.Return(Unit.Default))
                 .Aggregate(Unit.Default, (acc, x) => acc);
-        }
-    }
-
-    public class DidntFollowInstructionsAppSetup : AppSetup
-    {
-        readonly string shortCutName;
-        public override string ShortcutName {
-            get { return shortCutName; }
-        }
-
-        readonly string target;
-        public override string Target { get { return target; } }
-
-        public DidntFollowInstructionsAppSetup(string exeFile)
-        {
-            var fvi = FileVersionInfo.GetVersionInfo(exeFile);
-            shortCutName = fvi.ProductName ?? fvi.FileDescription ?? fvi.FileName.Replace(".exe", "");
-            target = exeFile;
         }
     }
 }

--- a/src/Shimmer.Core/ReactiveUIMicro/ReactiveUI/Logging.cs
+++ b/src/Shimmer.Core/ReactiveUIMicro/ReactiveUI/Logging.cs
@@ -270,11 +270,12 @@ namespace ReactiveUIMicro
 
         public WrappingFullLogger(IRxUILogger inner, Type callingType)
         {
+            Contract.Ensures(stringFormat != null);
+
             _inner = inner;
             prefix = String.Format(CultureInfo.InvariantCulture, "{0}: ", callingType.Name);
 
             stringFormat = typeof (String).GetMethod("Format", new[] {typeof (IFormatProvider), typeof (string), typeof (object[])});
-            Contract.Requires(stringFormat != null);
         }
 
         public void Debug<T>(T value)


### PR DESCRIPTION
Resolves #141 

Done:
- bail out of `fixPinnedExecutables` when there are no old directories
- introduced `Func` to either create the ShellLink or skip (no more tears and errors)
- moved `DidntFollowInstructionsAppSetup` to own class
- coding style and some minor tidy up
- code contracts build error (back :soon:) 
