### PR TITLE
Be less hand-hold-y with New-Release because there are some limitations:

### DIFF
--- a/src/CreateReleasePackage/tools/visualstudio.psm1
+++ b/src/CreateReleasePackage/tools/visualstudio.psm1
@@ -28,7 +28,7 @@ function New-Release {
     # we expect you to be a responsible adult
     # with your artifacts
 
-    if ($psversiontable.psversion.major -gt 2) {
+    if ($psversiontable.psversion.major -gt 3) {
 
         if (Test-Path $buildDir) {
             Write-Message "Clearing existing nupkg files from folder $outputDir"

--- a/src/CreateReleasePackage/tools/visualstudio.psm1
+++ b/src/CreateReleasePackage/tools/visualstudio.psm1
@@ -22,16 +22,30 @@ function New-Release {
     $outputDir =  $activeConfiguration.Properties.Item("OutputPath").Value
 
     $buildDir = Join-Path $projectDir $outputDir
-    if (Test-Path $buildDir) {
-        Write-Message "Clearing existing nupkg files from folder $outputDir"
-        Remove-Item "$buildDir\*.nupkg"
-    } else {
-        Write-Message "Build output folder $buildDir does not exist, skipping"
+
+    # because the EnvDTE build operations doesn't block on Win7
+    # we're not going to clean up packages here because
+    # we expect you to be a responsible adult
+    # with your artifacts
+
+    if ($psversiontable.psversion.major -gt 2) {
+
+        if (Test-Path $buildDir) {
+            Write-Message "Clearing existing nupkg files from folder $outputDir"
+            Remove-Item "$buildDir\*.nupkg"
+        } else {
+            Write-Message "Build output folder $buildDir does not exist, skipping"
+        }
+
+        Write-Message "Building project $ProjectName"
+
+        $dte.Solution.SolutionBuild.Clean($true)
+
+        $dte.Solution.SolutionBuild.BuildProject( `
+            $activeConfiguration.ConfigurationName, `
+            $project.FullName, `
+            $true)
     }
-
-    Write-Message "Building project $ProjectName"
-
-    $dte.Solution.SolutionBuild.BuildProject($activeConfiguration.ConfigurationName, $project.FullName, $true)
 
     Write-Message "Publishing release for project $ProjectName"
 


### PR DESCRIPTION
The EnvDTE operations for building a project do not block on Windows 7 (Powershell v2), so our attempts to clean up stale packages and build them are flawed for some users.

Let's opt-in if you're running Powershell v3 or later. Fixes an issue raised in #177 but does not resolve it.

Oh, and I'm cleaning the solution too. Resolves #167. 

Ping @peters
