### PR TITLE
Internalize the EnumerableExtensions class

### DIFF
--- a/src/Shimmer.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Shimmer.Core/Extensions/EnumerableExtensions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace System.Linq
 {
-    public static class EnumerableExtensions
+    internal static class EnumerableExtensions
     {
         /// <summary>
         /// Enumerates the sequence and invokes the given action for each value in the sequence.


### PR DESCRIPTION
Because some people are probably still using Ix_Experimental-Main even if Rx is now up to v2
