### PR TITLE
the proper exceptions should propagate when you await UpdateManager.CheckForUpdate

### DIFF
--- a/script/Run-UnitTests.ps1
+++ b/script/Run-UnitTests.ps1
@@ -18,7 +18,7 @@ function Run-XUnit([string]$project, [int]$timeoutDuration) {
         $output += Get-Content $outputPath
         $exitCode = $process.ExitCode
     } else {
-        $output += "Tests timed out. Backtrace:"
+        $output += "Tests timed out"
         $exitCode = 9999
     }
     Stop-Process -InputObject $process

--- a/src/Shimmer.Client/FrozenException.cs
+++ b/src/Shimmer.Client/FrozenException.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+
+namespace Shimmer.Client
+{
+    // this is actually an expensive operation
+    // but we want to preserve the stack trace
+    // and rethrow it later
+
+    // unfortunately we don't have .NET45 here
+    // and Observable.Throw doesn't care
+    // so we need to snapshot and hold onto it
+    public abstract class FrozenException : Exception
+    {
+        readonly string stackTrace;
+
+        protected FrozenException()
+        {
+            var trace = new StackTrace(2, true);
+            stackTrace = trace.ToString();
+        }
+
+        protected FrozenException(string message)
+            : base(message)
+        {
+            var trace = new StackTrace(2, true);
+            stackTrace = trace.ToString();
+        }
+
+        protected FrozenException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            var trace = new StackTrace(2, true);
+            stackTrace = trace.ToString();
+        }
+
+        protected FrozenException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            var trace = new StackTrace(2, true);
+            stackTrace = trace.ToString();
+        }
+
+        public override string StackTrace
+        {
+            get { return stackTrace; }
+        }
+    }
+}

--- a/src/Shimmer.Client/Shimmer.Client.csproj
+++ b/src/Shimmer.Client/Shimmer.Client.csproj
@@ -136,6 +136,7 @@
     <Compile Include="BitsManager.cs" />
     <Compile Include="DidntFollowInstructionsAppSetup.cs" />
     <Compile Include="Extensions\PackageExtensions.cs" />
+    <Compile Include="FrozenException.cs" />
     <Compile Include="IAppSetup.cs" />
     <Compile Include="InstallerHookOperations.cs" />
     <Compile Include="InstallManager.cs" />

--- a/src/Shimmer.Client/ShimmerConfigurationException.cs
+++ b/src/Shimmer.Client/ShimmerConfigurationException.cs
@@ -1,8 +1,6 @@
-﻿using System;
-
-namespace Shimmer.Client
+﻿namespace Shimmer.Client
 {
-    public class ShimmerConfigurationException : Exception
+    public class ShimmerConfigurationException : FrozenException
     {
         public ShimmerConfigurationException(string message) : base(message) { }
     }

--- a/src/Shimmer.Core/ReactiveUIMicro/Rx-Shim/AwaitableAsyncSubject.cs
+++ b/src/Shimmer.Core/ReactiveUIMicro/Rx-Shim/AwaitableAsyncSubject.cs
@@ -330,7 +330,7 @@ namespace ReactiveUIMicro
             }
 
             if (_exception != null) {
-                throw new InvalidOperationException("AwaitableAsyncSubject<T>.GetResult() is rethrowing an inner exception", _exception);
+                throw _exception;
             }
 
             if (!_hasValue)

--- a/src/Shimmer.Tests/Client/UpdateManagerTests.cs
+++ b/src/Shimmer.Tests/Client/UpdateManagerTests.cs
@@ -216,7 +216,6 @@ namespace Shimmer.Tests.Client
                 }
             }
 
-
             [Fact]
             public void WhenFolderDoesNotExistThrowHelpfulErrorAsync()
             {
@@ -228,8 +227,13 @@ namespace Shimmer.Tests.Client
 
                     using (fixture)
                     {
-                        AssertEx.TaskThrows<ShimmerConfigurationException>(
+                        var ex = AssertEx.TaskThrows<ShimmerConfigurationException>(
                             async () => await fixture.CheckForUpdate());
+
+                        Assert.False(string.IsNullOrWhiteSpace(ex.StackTrace));
+
+                        var firstLine = ex.StackTrace.Substring(0, ex.StackTrace.IndexOf("\r\n"));
+                        Assert.True(firstLine.Contains("Shimmer.Client.UpdateManager.checkForUpdate("));
                     }
                 }
             }
@@ -244,8 +248,13 @@ namespace Shimmer.Tests.Client
 
                     using (fixture)
                     {
-                        AssertEx.TaskThrows<ShimmerConfigurationException>(
+                        var ex = AssertEx.TaskThrows<ShimmerConfigurationException>(
                             async () => await fixture.CheckForUpdate());
+
+                        Assert.False(string.IsNullOrWhiteSpace(ex.StackTrace), "The stacktrace is empty");
+
+                        var firstLine = ex.StackTrace.Substring(0, ex.StackTrace.IndexOf("\r\n"));
+                        Assert.True(firstLine.Contains("Shimmer.Client.UpdateManager.checkForUpdate("));
                     }
                 }
             }

--- a/src/Shimmer.Tests/Client/UpdateManagerTests.cs
+++ b/src/Shimmer.Tests/Client/UpdateManagerTests.cs
@@ -2,7 +2,9 @@
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text;
+using AssertExLib;
 using Moq;
+using ReactiveUIMicro;
 using Shimmer.Client;
 using Shimmer.Core;
 using Shimmer.Tests.TestHelpers;
@@ -180,9 +182,11 @@ namespace Shimmer.Tests.Client
                         Assert.False(updateInfo.ReleasesToApply.First().IsDelta);
                     }
                 }
-
             }
+        }
 
+        public class CheckForUpdatesTests
+        {
             [Fact]
             public void WhenFolderDoesNotExistThrowHelpfulError()
             {
@@ -208,6 +212,40 @@ namespace Shimmer.Tests.Client
                     using (fixture) {
                         Assert.Throws<ShimmerConfigurationException>(
                             () => fixture.CheckForUpdate().Wait());
+                    }
+                }
+            }
+
+
+            [Fact]
+            public void WhenFolderDoesNotExistThrowHelpfulErrorAsync()
+            {
+                string tempDir;
+                using (Utility.WithTempDirectory(out tempDir))
+                {
+                    var directory = Path.Combine(tempDir, "missing-folder");
+                    var fixture = new UpdateManager(directory, "MyAppName", FrameworkVersion.Net40);
+
+                    using (fixture)
+                    {
+                        AssertEx.TaskThrows<ShimmerConfigurationException>(
+                            async () => await fixture.CheckForUpdate());
+                    }
+                }
+            }
+
+            [Fact]
+            public void WhenReleasesFileDoesntExistThrowACustomErrorAsync()
+            {
+                string tempDir;
+                using (Utility.WithTempDirectory(out tempDir))
+                {
+                    var fixture = new UpdateManager(tempDir, "MyAppName", FrameworkVersion.Net40);
+
+                    using (fixture)
+                    {
+                        AssertEx.TaskThrows<ShimmerConfigurationException>(
+                            async () => await fixture.CheckForUpdate());
                     }
                 }
             }

--- a/src/Shimmer.Tests/Client/UpdateManagerTests.cs
+++ b/src/Shimmer.Tests/Client/UpdateManagerTests.cs
@@ -233,7 +233,7 @@ namespace Shimmer.Tests.Client
                         Assert.False(string.IsNullOrWhiteSpace(ex.StackTrace));
 
                         var firstLine = ex.StackTrace.Substring(0, ex.StackTrace.IndexOf("\r\n"));
-                        Assert.True(firstLine.Contains("Shimmer.Client.UpdateManager.checkForUpdate("));
+                        Assert.True(firstLine.Contains("at Shimmer.Client.UpdateManager"), "Got stacktrace: " + ex.StackTrace);
                     }
                 }
             }
@@ -254,7 +254,7 @@ namespace Shimmer.Tests.Client
                         Assert.False(string.IsNullOrWhiteSpace(ex.StackTrace), "The stacktrace is empty");
 
                         var firstLine = ex.StackTrace.Substring(0, ex.StackTrace.IndexOf("\r\n"));
-                        Assert.True(firstLine.Contains("Shimmer.Client.UpdateManager.checkForUpdate("));
+                        Assert.True(firstLine.Contains("at Shimmer.Client.UpdateManager"), "Got stacktrace: " + ex.StackTrace);
                     }
                 }
             }

--- a/src/Shimmer.Tests/Shimmer.Tests.csproj
+++ b/src/Shimmer.Tests/Shimmer.Tests.csproj
@@ -68,6 +68,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AssertExLib">
+      <HintPath>..\packages\AssertEx.1.0.0\lib\net40\AssertExLib.dll</HintPath>
+    </Reference>
     <Reference Include="BootstrapperCore, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL" />
     <Reference Include="Ionic.Zip, Version=1.9.1.9000, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Shimmer.Tests/packages.config
+++ b/src/Shimmer.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AssertEx" version="1.0.0" targetFramework="net40" />
+  <package id="Caliburn.Micro" version="1.5.2" />
   <package id="MarkdownSharp" version="1.13.0.0" />
   <package id="Microsoft.Bcl" version="1.1.3" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.16" targetFramework="net40" />
@@ -7,6 +9,8 @@
   <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net40" />
   <package id="Moq" version="4.1.1309.1617" targetFramework="net40" />
   <package id="Moq.Contrib" version="0.3" />
+  <package id="Newtonsoft.Json" version="5.0.6" />
+  <package id="NLog" version="2.0.1.2" />
   <package id="NuGet.Core" version="2.7.0" targetFramework="net40" />
   <package id="reactiveui-core" version="4.6.5" targetFramework="net40" allowedVersions="[4,5)" />
   <package id="reactiveui-testing" version="4.6.5" targetFramework="net40" allowedVersions="[4,5)" />
@@ -22,18 +26,4 @@
   <package id="System.IO.Abstractions.TestingHelpers" version="1.4.0.66" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
-  <!--
-       START EVIL EVIL EVIL TRICKS
-       not referenced but packages indirectly need this
-       so rather than manually adding shit in within the test
-       i'm gonna restore it as part of the CI scripts
-
-       everything is terrible and no-one is upset
-  -->
-  <package id="Caliburn.Micro" version="1.5.2" />
-  <package id="NLog" version="2.0.1.2" />
-  <package id="Newtonsoft.Json" version="5.0.6" />
-  <!--
-      END EVIL EVIL EVIL TRICKS
-  -->
 </packages>


### PR DESCRIPTION
- [x] drop the InvalidOperationException and throw the raw exception
- [x] workaround the lack of StackTrace by taking a snapshot inside the ctor
- [x] make the tests pass
