### PR TITLE
Fix WithTempDirectory

### DIFF
--- a/src/Squirrel.Core/Utility.cs
+++ b/src/Squirrel.Core/Utility.cs
@@ -134,7 +134,7 @@ namespace Squirrel.Core
             path = tempDir.FullName;
 
             return Disposable.Create(() =>
-                DeleteDirectory(tempDir.FullName));
+                DeleteDirectory(tempDir.FullName).Wait());
         }
 
         public static IObservable<Unit> DeleteDirectory(string directoryPath, IScheduler scheduler = null)

--- a/src/Squirrel.Core/Utility.cs
+++ b/src/Squirrel.Core/Utility.cs
@@ -171,12 +171,12 @@ namespace Squirrel.Core
                 Observable.Start(() => {
                     Log().Debug("Now deleting file: {0}", file);
                     File.SetAttributes(file, FileAttributes.Normal);
-                    File.Delete(Path.Combine(directoryPath, file));
+                    File.Delete(file);
                 }, scheduler))
             .Select(_ => Unit.Default);
 
             var directoryOperations =
-                dirs.MapReduce(dir => DeleteDirectory(Path.Combine(directoryPath, dir), scheduler)
+                dirs.MapReduce(dir => DeleteDirectory(dir, scheduler)
                     .Retry(3))
                     .Select(_ => Unit.Default);
 


### PR DESCRIPTION
In 61b3aaa5757ef1768ac8ed73122473020c66d9a8, `WithTempDirectory` was changed to defer its actions; this left all the temp files on the disk when running tests.
