### PR TITLE
WIP: Named pipes for closing the app

### DIFF
--- a/src/Squirrel.Client/InstallManager.cs
+++ b/src/Squirrel.Client/InstallManager.cs
@@ -218,9 +218,8 @@ namespace Squirrel.Client
             var subject = new Subject<Unit>();
 
             Task.Factory.StartNew(() => {
-                var pipeServer = new NamedPipeServerStream(GetPipeName(applicationName), PipeDirection.InOut);
-                while (true)
-                {
+                while (true) {
+                    var pipeServer = new NamedPipeServerStream(GetPipeName(applicationName), PipeDirection.InOut);
                     pipeServer.WaitForConnection();
                     try
                     {
@@ -238,6 +237,10 @@ namespace Squirrel.Client
                     catch (IOException ex)
                     {
                         log.ErrorException("Named pipe server failed", ex);
+                    }
+                    finally
+                    {
+                        pipeServer.Close();
                     }
                 }
             });

--- a/src/Squirrel.WiXUi/WixUiBootstrapper.cs
+++ b/src/Squirrel.WiXUi/WixUiBootstrapper.cs
@@ -165,6 +165,14 @@ namespace Squirrel.WiXUi.ViewModels
                 }
 
                 if (wixEvents.Action == LaunchAction.Uninstall) {
+                    var appExitedIfRunning = installManager.RequestExitAndWait().Wait();
+                    if (!appExitedIfRunning) {
+                        // TODO: make UI ask whether to cancel/retry/force continue (restart needed)
+                        UserError.Throw(new UserError("App was open and was requested to exit, but didn't exit in time."
+                            + " Cancelling uninstall."));
+                        return;
+                    }
+
                     var task = installManager.ExecuteUninstall(BundledRelease.Version);
                     task.Subscribe(
                         _ => wixEvents.Engine.Apply(wixEvents.MainWindowHwnd),

--- a/src/Squirrel.WiXUi/WixUiBootstrapper.cs
+++ b/src/Squirrel.WiXUi/WixUiBootstrapper.cs
@@ -165,13 +165,13 @@ namespace Squirrel.WiXUi.ViewModels
                 }
 
                 if (wixEvents.Action == LaunchAction.Uninstall) {
-                    var appExitedIfRunning = installManager.RequestExitAndWait().Wait();
-                    if (!appExitedIfRunning) {
-                        // TODO: make UI ask whether to cancel/retry/force continue (restart needed)
-                        UserError.Throw(new UserError("App was open and was requested to exit, but didn't exit in time."
-                            + " Cancelling uninstall."));
-                        return;
-                    }
+                    // Try and get the app closed if it's listening for exit requests
+                    // If it isn't, or fails to exit in time, we'll mark it for deletion on restart anyway
+                    //
+                    // TODO: if it was listening for an exit request make a ui to ask
+                    // whether to cancel/try again/continue anyway (restart needed)
+                    // and/or tell the user to close the app
+                    installManager.RequestExitAndWait().Wait();
 
                     var task = installManager.ExecuteUninstall(BundledRelease.Version);
                     task.Subscribe(


### PR DESCRIPTION
Having a go at #186, though the PR right now is incomplete. <del>Biggest issue is that I haven't worked out how to confirm whether my setup.exe is using my local build of Squirrel or the one in `packages`, so I'm not sure if the code I put in uninstall actually runs.</del> **Need to have tools dir updated** Otherwise, the code needs tidying up. Also tests

I've dropped this into a clone of [Shimmer.Samples](https://github.com/shiftkey/Shimmer.Samples) and so far can get it to compile<del>, and tell it to close with a separate command line app ([source](https://gist.github.com/rzhw/7114c0da8f707d67d09f))</del>, as well as with this in AppBootstrapper.cs:

```
InstallManager.ListenForClose("SquirrelDesktopDemo").Subscribe(
    _ => Application.Current.Dispatcher.Invoke(new Action(() => Application.Current.Shutdown())));
```

or

```
InstallManager.ListenForClose("SquirrelDesktopDemo")
    .ObserveOn(RxApp.DeferredScheduler)
    .Subscribe(_ => Application.Current.Shutdown());
```

---

This PR description needs cleaning up. List:
- [x] Basic code in uninstaller (named pipe client)
- [x] Basic code in app (named pipe server, needs to be set up to listen for exit request)
- <del>[ ] Uninstaller should ask retry/continue/cancel if exit request times out</del>
- <del>[ ] What if the app is running but doesn't receive exit request in time? (Does the named pipe client instantly know if the server is running - maybe assume if it's up then the app is running)</del>
- [ ] Clean up
- [ ] Tests
