### PR TITLE
Fix Bump-Version for when containing dir contains "Squirrel."

### DIFF
--- a/script/Bump-Version.ps1
+++ b/script/Bump-Version.ps1
@@ -36,7 +36,7 @@ function Write-VersionAssemblyInfo {
     }
 
     if ($numberOfReplacements -ne 3) {
-        Die "Expected to replace the version number in 3 places in AssemblyInfo.cs (AssemblyVersion, AssemblyFileVersion, AssemblyInformationalVersion) but actually replaced it in $numberOfReplacements"
+        Die "Expected to replace the version number in 3 places in $assemblyInfo (AssemblyVersion, AssemblyFileVersion, AssemblyInformationalVersion) but actually replaced it in $numberOfReplacements"
     }
 
     $newContent | Set-Content $assemblyInfo -Encoding UTF8

--- a/script/Bump-Version.ps1
+++ b/script/Bump-Version.ps1
@@ -70,7 +70,9 @@ $srcFolder = "$rootFolder\src"
 
 $items = Get-ChildItem -Path "$srcFolder" -Filter "AssemblyInfo.cs" -Recurse
 
-$items = $items | Where-Object {$_.FullName.Contains("Squirrel.") -or $_.FullName.COntains("CreateReleasePackage")}
+# Get AssemblyInfo.cs files of projects that contain "Squirrel." or are "CreateReleasePackage"
+# However the solution itself might be in a folder that contains "Squirrel." so only look at the last bit
+$items = $items | Where-Object { ($_.FullName -replace "^.*(?=\\(.*?)\\Properties\\AssemblyInfo\.cs)", "").Contains("Squirrel.") -or $_.FullName.Contains("CreateReleasePackage") }
 
 $currentVersion = [System.Version](Read-VersionAssemblyInfo $items[0].FullName)
 

--- a/script/bootstrap.ps1
+++ b/script/bootstrap.ps1
@@ -5,7 +5,16 @@ $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 $rootFolder = (Get-Item $scriptPath).Parent.FullName
 $srcFolder = "$rootFolder\src"
 
-git submodule init
+try {
+    git submodule init
+} catch {
+    Write-Host "Git not found!" -ForegroundColor Red
+    Write-Host
+    Write-Host "If you have Git installed you should add at least PATH_TO_GIT\cmd to your path"
+    Write-Host "For most people, this would be C:\Program Files (x86)\Git\cmd"
+    Write-Host
+    throw
+}
 
 $nuget = "$srcFolder\.nuget\nuget.exe"
 


### PR DESCRIPTION
Since cloning put everything in "Squirrel.Windows" it was tripping up Bump-Version. It was trying to run on SampleUpdatingApp's AssemblyInfo (which has version 1.3.0.0 versus the other projects at 0.7.x) and failing.

Also threw in a quick tip into bootstrap for people without Git in their path
