### PR TITLE
Remove ICreatesObservableForProperty checks from WiXUiBootstrapperTests

### DIFF
--- a/src/Squirrel.Tests/WiXUi/WiXUiBootstrapperTests.cs
+++ b/src/Squirrel.Tests/WiXUi/WiXUiBootstrapperTests.cs
@@ -38,7 +38,6 @@ namespace Squirrel.Tests.WiXUi
             string dir;
             using (IntegrationTestHelper.WithFakeInstallDirectory(out dir)) {
                 var fixture = new WixUiBootstrapper(events.Object, null, router, null, dir);
-                RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
                 Func<uint, int> convertHResult = hr => BitConverter.ToInt32(BitConverter.GetBytes(hr), 0);
 
@@ -78,7 +77,6 @@ namespace Squirrel.Tests.WiXUi
             string dir;
             using (IntegrationTestHelper.WithFakeInstallDirectory(out dir)) {
                 var fixture = new WixUiBootstrapper(events.Object, null, router, null, dir);
-                RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
                 detectComplete.OnNext(new DetectPackageCompleteEventArgs("UserApplicationId", 0, PackageState.Absent));
 
@@ -109,7 +107,6 @@ namespace Squirrel.Tests.WiXUi
             string dir;
             using (IntegrationTestHelper.WithFakeInstallDirectory(out dir)) {
                 var fixture = new WixUiBootstrapper(events.Object, null, router, null, dir);
-                RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
                 detectComplete.OnNext(new DetectPackageCompleteEventArgs("UserApplicationId", 0, PackageState.Absent));
 
@@ -162,7 +159,6 @@ namespace Squirrel.Tests.WiXUi
                 firstEvents.SetupGet(x => x.Action).Returns(LaunchAction.Install);
 
                 var firstFixture = new WixUiBootstrapper(firstEvents.Object, firstKernel, firstRouter, null, dir, targetRootDirectory);
-                RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
                 mockPerformInstall(firstRouter, firstDetectPackage, firstPlanComplete, firstApplyComplete, firstEngine);
 
@@ -297,7 +293,6 @@ namespace Squirrel.Tests.WiXUi
                 secondEvents.SetupGet(x => x.Action).Returns(LaunchAction.Uninstall);
 
                 var secondFixture = new WixUiBootstrapper(secondEvents.Object, secondKernel, secondRouter, null, dir, targetRootDirectory);
-                RxApp.GetAllServices<ICreatesObservableForProperty>().Any().ShouldBeTrue();
 
                 mockPerformUninstall(secondDetectPackage, secondPlanComplete, secondApplyComplete, secondEngine);
 


### PR DESCRIPTION
This reduces the failing tests from 23 to 18.

I'm not absolutely certain what ICreatesObservableForProperty is around in the code for now, but given the summary in ReactiveUI/RegisterableInterfaces.cs:

```
/// <summary>
/// ICreatesObservableForProperty represents an object that knows how to
/// create notifications for a given type of object. Implement this if you
/// are porting RxUI to a new UI toolkit, or generally want to enable WhenAny
/// for another type of object that can be observed in a unique way.
/// </summary>
```

and that the tests in `WhenAnyTests` all pass, as well as the use of WhenAny for only `IReactiveNotifyPropertyChanged`s i.e. being covered by `WhenAnyShim`, it looks like things are safe
