### PR TITLE
Fix the Bump-Version script

### DIFF
--- a/script/Bump-Version.ps1
+++ b/script/Bump-Version.ps1
@@ -70,7 +70,7 @@ $srcFolder = "$rootFolder\src"
 
 $items = Get-ChildItem -Path "$srcFolder" -Filter "AssemblyInfo.cs" -Recurse
 
-$items = $items | Where-Object {$_.FullName.Contains("Squirrel.") -or $_.FullName.COntains("CreateReleasePackage")}
+$items = $items | Where-Object {$_.FullName.Contains("src\Squirrel.") -or $_.FullName.Contains("src\CreateReleasePackage")}
 
 $currentVersion = [System.Version](Read-VersionAssemblyInfo $items[0].FullName)
 


### PR DESCRIPTION
Previously it would include any occurrence of "Squirrel." in the path, for example `C:\\Squirrel.Windows\src\SampleUpdatingApp`

Also fixed a typo
